### PR TITLE
Fix running & building under macOS (Big Sur)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1601961544,
-        "narHash": "sha256-uuh9CkDWkXlXse8IcergqoIM5JffqfQDKsl1uHB7XJI=",
+        "lastModified": 1605716121,
+        "narHash": "sha256-CbHicvkzLTfEY+aSUeUY7dfFlDOgZH3uK+PpUfb/DPA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "89281dd1dfed6839610f0ccad0c0e493606168fe",
+        "rev": "6625284c397b44bc9518a5a1567c1b5aae455c08",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,12 @@
       in
       {
         defaultPackage = self.packages."${system}".deploy-rs;
-        packages.deploy-rs = naersk-lib.buildPackage ./.;
+        packages.deploy-rs = naersk-lib.buildPackage {
+          root = ./.;
+          propagatedNativeBuildInputs = [ pkgs.xcbuild ];
+          nativeBuildInputs = [ pkgs.xcbuild ];
+          cargoBuildOptions = opts: opts ++ [ "--verbose" ];
+        };
 
         defaultApp = self.apps."${system}".deploy-rs;
         apps.deploy-rs = {


### PR DESCRIPTION
I've been meaning to try deploy-rs, but I run macOS; since it doesn't currently build there (the `activate` binary has a linux-only inotify dependency, and there was a version incompatibility that prevented building on my OS release), here's a patch that makes it work.

I think this PR ought to retain compatibility with Linux.

## What's it do in detail?

* Bumps nixpkgs to a version that ships rust 1.47, as older binaries don't correctly link on macOS 11.0
* Special-cases out the `activate` binary on macOS (and activates `singleStep` mode there for https://github.com/nmattia/naersk/issues/127
* Adds some native build flags necessary to get a working build env on macOS.

Hope this looks reasonable! I'm still evaluating deploy-rs, but it does show `--help` on macOS with this change, at least (: