### PR TITLE
Use the stored activate binary appropriate for target platform

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,7 +101,9 @@
                   node_name=$(echo $x | cut -f2 -d:)
                   profile_name=$(echo $x | cut -f3 -d:)
 
-                  test -f "$profile_path/deploy-rs-activate" || (echo "#$node_name.$profile_name is missing an activation script" && exit 1);
+                  test -f "$profile_path/deploy-rs-activate" || (echo "#$node_name.$profile_name is missing the deploy-rs-activate activation script" && exit 1);
+
+                  test -f "$profile_path/activate-rs" || (echo "#$node_name.$profile_name is missing the activate-rs activation script" && exit 1);
                 done
 
                 touch $out

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,15 @@
                   executable = true;
                   destination = "/deploy-rs-activate";
                 })
+                (pkgs.writeTextFile {
+                  name = base.name + "-activate-rs";
+                  text = ''
+                    #!${pkgs.runtimeShell}
+                    exec ${self.defaultPackage."${system}"}/bin/activate "$@"
+                  '';
+                  executable = true;
+                  destination = "/activate-rs";
+                })
               ];
             };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
+# SPDX-FileCopyrightText: 2020 Andreas Fuchs <asf@boinkor.net>
 #
 # SPDX-License-Identifier: MPL-2.0
 

--- a/src/utils/deploy.rs
+++ b/src/utils/deploy.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
+// SPDX-FileCopyrightText: 2020 Andreas Fuchs <asf@boinkor.net>
 //
 // SPDX-License-Identifier: MPL-2.0
 

--- a/src/utils/deploy.rs
+++ b/src/utils/deploy.rs
@@ -89,7 +89,7 @@ pub async fn deploy_profile(
         deploy_data.profile_name, deploy_data.node_name
     );
 
-    let activate_path_str = super::deploy_path_to_activate_path_str(&deploy_defs.current_exe)?;
+    let activate_path_str = super::deploy_path_to_activate_path_str(deploy_defs)?;
 
     let temp_path: Cow<str> = match &deploy_data.merged_settings.temp_path {
         Some(x) => x.into(),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
+// SPDX-FileCopyrightText: 2020 Andreas Fuchs <asf@boinkor.net>
 //
 // SPDX-License-Identifier: MPL-2.0
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -112,7 +112,6 @@ pub struct DeployDefs {
     pub ssh_user: String,
     pub profile_user: String,
     pub profile_path: String,
-    pub current_exe: PathBuf,
     pub sudo: Option<String>,
 }
 
@@ -173,7 +172,6 @@ impl<'a> DeployData<'a> {
             ssh_user,
             profile_user,
             profile_path,
-            current_exe,
             sudo,
         })
     }
@@ -231,25 +229,21 @@ pub enum DeployPathToActivatePathError {
 }
 
 pub fn deploy_path_to_activate_path_str(
-    deploy_path: &std::path::Path,
+    deploy_defs: &DeployDefs,
 ) -> Result<String, DeployPathToActivatePathError> {
-    Ok(format!(
-        "{}/activate",
-        deploy_path
-            .parent()
-            .ok_or(DeployPathToActivatePathError::PathTooShort)?
-            .to_str()
-            .ok_or(DeployPathToActivatePathError::InvalidUtf8)?
-            .to_owned()
-    ))
+    Ok(format!("{}/activate-rs", deploy_defs.profile_path))
 }
 
 #[test]
 fn test_activate_path_generation() {
-    match deploy_path_to_activate_path_str(&std::path::PathBuf::from(
-        "/blah/blah/deploy-rs/bin/deploy",
-    )) {
+    let defs = DeployDefs {
+        ssh_user: "foo".to_string(),
+        profile_user: "bar".to_string(),
+        profile_path: "/nix/store/profile-closure".to_string(),
+        sudo: None,
+    };
+    match deploy_path_to_activate_path_str(&defs) {
         Err(_) => panic!(""),
-        Ok(x) => assert_eq!(x, "/blah/blah/deploy-rs/bin/activate".to_string()),
+        Ok(x) => assert_eq!(x, "/nix/store/profile-closure/activate-rs".to_string()),
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -118,11 +118,6 @@ pub struct DeployDefs {
 #[derive(Error, Debug)]
 pub enum DeployDataDefsError {
     #[error("Neither `user` nor `sshUser` are set for profile {0} of node {1}")]
-    NoProfileUser(String, String),
-    #[error("Error reading current executable path: {0}")]
-    ExecutablePathNotFound(std::io::Error),
-    #[error("Executable was not in the Nix store")]
-    NotNixStored,
 }
 
 impl<'a> DeployData<'a> {
@@ -160,13 +155,6 @@ impl<'a> DeployData<'a> {
             Some(ref user) if user != &ssh_user => Some(format!("sudo -u {}", user)),
             _ => None,
         };
-
-        let current_exe =
-            std::env::current_exe().map_err(DeployDataDefsError::ExecutablePathNotFound)?;
-
-        if !current_exe.starts_with("/nix/store/") {
-            return Err(DeployDataDefsError::NotNixStored);
-        }
 
         Ok(DeployDefs {
             ssh_user,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -118,6 +118,7 @@ pub struct DeployDefs {
 #[derive(Error, Debug)]
 pub enum DeployDataDefsError {
     #[error("Neither `user` nor `sshUser` are set for profile {0} of node {1}")]
+    NoProfileUser(String, String),
 }
 
 impl<'a> DeployData<'a> {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -227,23 +227,3 @@ pub enum DeployPathToActivatePathError {
     #[error("Deploy path was not valid utf8")]
     InvalidUtf8,
 }
-
-pub fn deploy_path_to_activate_path_str(
-    deploy_defs: &DeployDefs,
-) -> Result<String, DeployPathToActivatePathError> {
-    Ok(format!("{}/activate-rs", deploy_defs.profile_path))
-}
-
-#[test]
-fn test_activate_path_generation() {
-    let defs = DeployDefs {
-        ssh_user: "foo".to_string(),
-        profile_user: "bar".to_string(),
-        profile_path: "/nix/store/profile-closure".to_string(),
-        sudo: None,
-    };
-    match deploy_path_to_activate_path_str(&defs) {
-        Err(_) => panic!(""),
-        Ok(x) => assert_eq!(x, "/nix/store/profile-closure/activate-rs".to_string()),
-    }
-}

--- a/src/utils/push.rs
+++ b/src/utils/push.rs
@@ -103,9 +103,7 @@ pub async fn push_profile(
             .arg("-k")
             .arg(local_key)
             .arg(&deploy_data.profile.profile_settings.path)
-            .arg(&super::deploy_path_to_activate_path_str(
-                &deploy_defs.current_exe,
-            )?)
+            .arg(&super::deploy_path_to_activate_path_str(&deploy_defs)?)
             .status()
             .await
             .map_err(PushProfileError::SignError)?;
@@ -150,9 +148,7 @@ pub async fn push_profile(
         .arg("--to")
         .arg(format!("ssh://{}@{}", deploy_defs.ssh_user, hostname))
         .arg(&deploy_data.profile.profile_settings.path)
-        .arg(&super::deploy_path_to_activate_path_str(
-            &deploy_defs.current_exe,
-        )?)
+        .arg(&super::deploy_path_to_activate_path_str(&deploy_defs)?)
         .env("NIX_SSHOPTS", ssh_opts_str)
         .status()
         .await

--- a/src/utils/push.rs
+++ b/src/utils/push.rs
@@ -148,7 +148,6 @@ pub async fn push_profile(
         .arg("--to")
         .arg(format!("ssh://{}@{}", deploy_defs.ssh_user, hostname))
         .arg(&deploy_data.profile.profile_settings.path)
-        .arg(&super::deploy_path_to_activate_path_str(&deploy_defs)?)
         .env("NIX_SSHOPTS", ssh_opts_str)
         .status()
         .await

--- a/src/utils/push.rs
+++ b/src/utils/push.rs
@@ -103,7 +103,6 @@ pub async fn push_profile(
             .arg("-k")
             .arg(local_key)
             .arg(&deploy_data.profile.profile_settings.path)
-            .arg(&super::deploy_path_to_activate_path_str(&deploy_defs)?)
             .status()
             .await
             .map_err(PushProfileError::SignError)?;

--- a/src/utils/push.rs
+++ b/src/utils/push.rs
@@ -4,6 +4,7 @@
 
 use std::process::Stdio;
 use tokio::process::Command;
+use std::path::Path;
 
 use thiserror::Error;
 
@@ -15,6 +16,12 @@ pub enum PushProfileError {
     BuildError(std::io::Error),
     #[error("Nix build command resulted in a bad exit code: {0:?}")]
     BuildExitError(Option<i32>),
+    #[error("Activation script deploy-rs-activate does not exist in profile.\n\
+             Did you forget to use deploy-rs#lib.<...>.activate.<...> on your profile path?")]
+    DeployRsActivateDoesntExist,
+    #[error("Activation script activate-rs does not exist in profile.\n\
+             Is there a mismatch in deploy-rs used in the flake you're deploying and deploy-rs command you're running?")]
+    ActivateRsDoesntExist,
     #[error("Failed to run Nix sign command: {0}")]
     SignError(std::io::Error),
     #[error("Nix sign command resulted in a bad exit code: {0:?}")]
@@ -90,6 +97,16 @@ pub async fn push_profile(
         Some(0) => (),
         a => return Err(PushProfileError::BuildExitError(a)),
     };
+
+    if ! Path::new(format!("{}/deploy-rs-activate", deploy_data.profile.profile_settings.path).as_str()).exists() {
+        return Err(PushProfileError::DeployRsActivateDoesntExist);
+    }
+
+    if ! Path::new(format!("{}/activate-rs", deploy_data.profile.profile_settings.path).as_str()).exists() {
+        return Err(PushProfileError::ActivateRsDoesntExist);
+    }
+
+
 
     if let Ok(local_key) = std::env::var("LOCAL_KEY") {
         info!(


### PR DESCRIPTION
This addresses #13.

This PR rips out the `current_exe` field, preferring to write an `activate-rs` script that points to the platform-appropriate activation binary.

Then, the deploy binary attempts to use that activate-rs script to activate the profile closure.

I've successfully run a deploy to an amd64 linux installation from my intel macOS machine, so I suspect this might work (: