### PR TITLE
Debump the smol_str version to 0.1.16 to build on rust 1.45.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "smol_str",
  "thiserror",
  "tokio",
  "toml",
@@ -652,9 +653,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smol_str"
-version = "0.1.17"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca0f7ce3a29234210f0f4f0b56f8be2e722488b95cb522077943212da3b32eb"
+checksum = "2f7909a1d8bc166a862124d84fdc11bda0ea4ed3157ccca662296919c2972db1"
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "1.0"
 toml = "0.5"
 yn = "0.1"
 rnix = "0.8"
+smol_str = "=0.1.16" # required by rnix, but 0.1.17 doesn't build on nixos-20.09
 
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,11 @@ thiserror = "1.0"
 toml = "0.5"
 yn = "0.1"
 rnix = "0.8"
-smol_str = "=0.1.16" # required by rnix, but 0.1.17 doesn't build on nixos-20.09
+
+# smol_str is required by rnix, but 0.1.17 doesn't build on rustc
+# 1.45.2 (shipped in nixos-20.09); it requires rustc 1.46.0. See
+# <https://github.com/serokell/deploy-rs/issues/27>:
+smol_str = "=0.1.16"
 
 
 [[bin]]


### PR DESCRIPTION
This addresses #27: Rust 1.45.2 is what ships in the 20.09 release, and smol_str 0.1.17 is
incompatible with it.

I think there's still a puzzle piece missing, namely some form of CI that asserts deploy-rs keeps working with the nix releases that you wish to support (I am making the assumption that 20.09 is a reasonable target for now).