### PR TITLE
Make magicRollback use pseudo-terminal allocation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,9 @@ struct Opts {
     /// Override the SSH options used
     #[clap(long)]
     ssh_opts: Option<String>,
+    /// Use interactive TTY over SSH
+    #[clap(long)]
+    ssh_interactive_tty: bool,
     /// Override if the connecting to the target node should be considered fast
     #[clap(long)]
     fast_connection: Option<bool>,
@@ -336,6 +339,7 @@ async fn run_deploy(
     keep_result: bool,
     result_path: Option<&str>,
     extra_build_args: &[String],
+    ssh_interactive_tty: bool,
 ) -> Result<(), RunDeployError> {
     let to_deploy: Vec<((&str, &utils::data::Node), (&str, &utils::data::Profile))> =
         match (&deploy_flake.node, &deploy_flake.profile) {
@@ -432,6 +436,7 @@ async fn run_deploy(
             profile,
             profile_name,
             &cmd_overrides,
+            &ssh_interactive_tty,
         );
 
         let deploy_defs = deploy_data.defs()?;
@@ -534,6 +539,7 @@ async fn run() -> Result<(), RunError> {
         opts.keep_result,
         result_path,
         &opts.extra_build_args,
+        opts.ssh_interactive_tty,
     )
     .await?;
 

--- a/src/utils/deploy.rs
+++ b/src/utils/deploy.rs
@@ -117,12 +117,16 @@ pub async fn deploy_profile(
     };
 
     let mut c = Command::new("ssh");
-    let mut ssh_command = c
-        .arg("-t")
-        .arg(format!("ssh://{}@{}", deploy_defs.ssh_user, hostname));
+    let mut ssh_command = c;
+
+    if *deploy_data.ssh_interactive_tty {
+        ssh_command.arg("-t");
+    }
+
+    ssh_command.arg(&format!("ssh://{}@{}", deploy_defs.ssh_user, hostname));
 
     for ssh_opt in &deploy_data.merged_settings.ssh_opts {
-        ssh_command = ssh_command.arg(ssh_opt);
+        ssh_command.arg(ssh_opt);
     }
 
     let ssh_exit_status = ssh_command
@@ -142,10 +146,16 @@ pub async fn deploy_profile(
         info!("Attempting to confirm activation");
 
         let mut c = Command::new("ssh");
-        let mut ssh_confirm_command = c.arg(format!("ssh://{}@{}", deploy_defs.ssh_user, hostname));
+        let mut ssh_confirm_command = c;
+
+        if *deploy_data.ssh_interactive_tty {
+            ssh_confirm_command.arg("-t");
+        }
+
+        ssh_confirm_command.arg(format!("ssh://{}@{}", deploy_defs.ssh_user, hostname));
 
         for ssh_opt in &deploy_data.merged_settings.ssh_opts {
-            ssh_confirm_command = ssh_confirm_command.arg(ssh_opt);
+            ssh_confirm_command.arg(ssh_opt);
         }
 
         let lock_hash = &deploy_data.profile.profile_settings.path["/nix/store/".len()..];

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -191,6 +191,8 @@ pub struct DeployData<'a> {
     pub cmd_overrides: &'a CmdOverrides,
 
     pub merged_settings: data::GenericSettings,
+
+    pub ssh_interactive_tty: &'a bool,
 }
 
 #[derive(Debug)]
@@ -259,6 +261,7 @@ pub fn make_deploy_data<'a, 's>(
     profile: &'a data::Profile,
     profile_name: &'a str,
     cmd_overrides: &'a CmdOverrides,
+    ssh_interactive_tty: &'a bool,
 ) -> DeployData<'a> {
     let mut merged_settings = profile.generic_settings.clone();
     merged_settings.merge(node.generic_settings.clone());
@@ -292,6 +295,8 @@ pub fn make_deploy_data<'a, 's>(
         cmd_overrides,
 
         merged_settings,
+
+        ssh_interactive_tty,
     }
 }
 


### PR DESCRIPTION
Solves issue with `magicRollback` where the `sshUser` is in group `wheel`. It asks for my sudo password like it should  but fails immediately after:
```
 INFO  deploy::utils::deploy > Success activating!
 INFO  deploy::utils::deploy > Attempting to confirm activation
sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper
sudo: a password is required
 ERROR deploy                > Failed to deploy profile: Confirming activation over SSH resulted in a bad exit code (the server should roll back): Some(1)
``` 