### PR TITLE
Set /tmp as the CWD for activation

### DIFF
--- a/src/activate.rs
+++ b/src/activate.rs
@@ -138,7 +138,7 @@ pub async fn deactivate(profile_path: &str) -> Result<(), DeactivateError> {
 
     let re_activate_exit_status = Command::new(format!("{}/deploy-rs-activate", profile_path))
         .env("PROFILE", &profile_path)
-        .current_dir(&profile_path)
+        .current_dir("/tmp")
         .status()
         .await
         .map_err(DeactivateError::ReactivateError)?;
@@ -303,7 +303,7 @@ pub async fn activate(
 
     let activate_status = match Command::new(format!("{}/deploy-rs-activate", profile_path))
         .env("PROFILE", &profile_path)
-        .current_dir(&profile_path)
+        .current_dir("/tmp")
         .status()
         .await
         .map_err(ActivateError::RunActivateError)


### PR DESCRIPTION
Due to a nixos bug (https://github.com/NixOS/nixpkgs/issues/73404), the activation requires CWD to be writeable; one canonical writeable directory is /tmp, so I picked that. This fixes the issue for me, and I can install initrd secrets with the fix in place.

I guess it would be reasonable to let users choose their own, but I'm not sure how to properly do that - maybe via a custom activation script?