### PR TITLE
Remove default loader entry on NixOS activation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,12 @@
               ];
             };
 
-            nixos = base: custom base.config.system.build.toplevel "$PROFILE/bin/switch-to-configuration switch";
+            nixos = base: custom base.config.system.build.toplevel ''
+              $PROFILE/bin/switch-to-configuration switch
+
+              # https://github.com/serokell/deploy-rs/issues/31
+              sed -i '/^default /d' /boot/loader/loader.conf
+            '';
 
             noop = base: custom base ":";
           };

--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,7 @@
               $PROFILE/bin/switch-to-configuration switch
 
               # https://github.com/serokell/deploy-rs/issues/31
-              sed -i '/^default /d' /boot/loader/loader.conf
+              sed -i '/^default /d' ${base.config.boot.loader.efi.efiSysMountPoint}/loader/loader.conf || :
             '';
 
             noop = base: custom base ":";

--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,9 @@
               $PROFILE/bin/switch-to-configuration switch
 
               # https://github.com/serokell/deploy-rs/issues/31
-              sed -i '/^default /d' ${base.config.boot.loader.efi.efiSysMountPoint}/loader/loader.conf || :
+              ${with base.config.boot.loader;
+              pkgs.lib.optionalString systemd-boot.enable
+              "sed -i '/^default /d' ${efi.efiSysMountPoint}/loader/loader.conf"}
             '';
 
             noop = base: custom base ":";


### PR DESCRIPTION
This should work around #31 in a backwards-compatible manner, it might be better to update that line rather than delete it (though the default without this line is the latest generation, which should be fine), but that would be more complex and we may not need it.

We should of course still fix this upstream in nixpkgs to eventually remove the need for this workaround