### PR TITLE
Raise wait timeout

### DIFF
--- a/src/activate.rs
+++ b/src/activate.rs
@@ -322,7 +322,7 @@ pub async fn wait(temp_path: String, closure: String) -> Result<(), WaitError> {
         return Ok(());
     }
 
-    danger_zone(done, 60).await?;
+    danger_zone(done, 240).await?;
 
     info!("Found canary file, done waiting!");
 


### PR DESCRIPTION
This stops problems from occuring when activation takes a long time to complete