### PR TITLE
Add Nix-flake check for checking build and Rust tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,10 @@
           buildInputs = [ pkgs.nixUnstable ];
         };
 
+        checks = {
+          deploy-rs = self.defaultPackage.${system}.overrideAttrs (super: { doCheck = true; });
+        };
+
         lib = rec {
 
           setActivate = builtins.trace


### PR DESCRIPTION
This will make `nix flake check` essentially run `cargo test`, and as it turns out it never attempts to build `defaultPackage` at all either, making our CI essentially useless, and this also fixes that.