### PR TITLE
Wait for activation

### DIFF
--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -138,6 +138,57 @@ fn test_wait_command_builder() {
 }
 
 #[derive(Error, Debug)]
+pub enum ConfirmProfileError {
+    #[error("Failed to run confirmation command over SSH (the server should roll back): {0}")]
+    SSHConfirmError(std::io::Error),
+    #[error(
+        "Confirming activation over SSH resulted in a bad exit code (the server should roll back): {0:?}"
+    )]
+    SSHConfirmExitError(Option<i32>),
+}
+
+pub async fn confirm_profile(
+    deploy_data: &super::DeployData<'_>,
+    deploy_defs: &super::DeployDefs,
+    hostname: &str,
+    temp_path: Cow<'_, str>,
+) -> Result<(), ConfirmProfileError> {
+    let mut c = Command::new("ssh");
+    let mut ssh_confirm_command = c.arg(format!("ssh://{}@{}", deploy_defs.ssh_user, hostname));
+
+    for ssh_opt in &deploy_data.merged_settings.ssh_opts {
+        ssh_confirm_command = ssh_confirm_command.arg(ssh_opt);
+    }
+
+    let lock_path = super::make_lock_path(&temp_path, &deploy_data.profile.profile_settings.path);
+
+    let mut confirm_command = format!("rm {}", lock_path);
+    if let Some(sudo_cmd) = &deploy_defs.sudo {
+        confirm_command = format!("{} {}", sudo_cmd, confirm_command);
+    }
+
+    debug!(
+        "Attempting to run command to confirm deployment: {}",
+        confirm_command
+    );
+
+    let ssh_confirm_exit_status = ssh_confirm_command
+        .arg(confirm_command)
+        .status()
+        .await
+        .map_err(ConfirmProfileError::SSHConfirmError)?;
+
+    match ssh_confirm_exit_status.code() {
+        Some(0) => (),
+        a => return Err(ConfirmProfileError::SSHConfirmExitError(a)),
+    };
+
+    info!("Deployment confirmed.");
+
+    Ok(())
+}
+
+#[derive(Error, Debug)]
 pub enum DeployProfileError {
     #[error("Failed to spawn activation command over SSH: {0}")]
     SSHSpawnActivateError(std::io::Error),
@@ -152,12 +203,8 @@ pub enum DeployProfileError {
     #[error("Waiting over SSH resulted in a bad exit code: {0:?}")]
     SSHWaitExitError(Option<i32>),
 
-    #[error("Failed to run confirmation command over SSH (the server should roll back): {0}")]
-    SSHConfirmError(std::io::Error),
-    #[error(
-        "Confirming activation over SSH resulted in a bad exit code (the server should roll back): {0:?}"
-    )]
-    SSHConfirmExitError(Option<i32>),
+    #[error("Error confirming deployment: {0}")]
+    ConfirmError(#[from] ConfirmProfileError),
 }
 
 pub async fn deploy_profile(
@@ -250,22 +297,33 @@ pub async fn deploy_profile(
         let (send_activated, recv_activated) = tokio::sync::oneshot::channel();
 
         tokio::spawn(async move {
-            send_activate
-                .send(ssh_activate.wait_with_output().await)
-                .unwrap();
+            let o = ssh_activate.wait_with_output().await;
+
+            // Don't event unless somethis is bad
+            // TODO: maybe replace the structure with our own
+            match o {
+                Ok(ref x) => match x.status.code() {
+                    Some(0) => (),
+                    _ => send_activate.send(o).unwrap(),
+                },
+                _ => send_activate.send(o).unwrap(),
+            };
+
             send_activated.send(()).unwrap();
         });
 
         tokio::select! {
             x = ssh_wait_command.arg(self_wait_command).status() => {
+                debug!("Wait command ended");
                 match x.map_err(DeployProfileError::SSHWaitError)?.code() {
                     Some(0) => (),
                     a => return Err(DeployProfileError::SSHWaitExitError(a)),
                 };
             },
             x = recv_activate => {
+                debug!("Activate command exited with an error");
                 match x.unwrap().map_err(DeployProfileError::SSHActivateError)?.status.code() {
-                    Some(0) => (),
+                    Some(0) => unreachable!(), // We know it is an error, see a comment above
                     a => return Err(DeployProfileError::SSHActivateExitError(a)),
                 };
             },
@@ -273,40 +331,9 @@ pub async fn deploy_profile(
 
         info!("Success activating, attempting to confirm activation");
 
-        let mut c = Command::new("ssh");
-        let mut ssh_confirm_command = c.arg(format!("ssh://{}@{}", deploy_defs.ssh_user, hostname));
-
-        for ssh_opt in &deploy_data.merged_settings.ssh_opts {
-            ssh_confirm_command = ssh_confirm_command.arg(ssh_opt);
-        }
-
-        let lock_path =
-            super::make_lock_path(&temp_path, &deploy_data.profile.profile_settings.path);
-
-        let mut confirm_command = format!("rm {}", lock_path);
-        if let Some(sudo_cmd) = &deploy_defs.sudo {
-            confirm_command = format!("{} {}", sudo_cmd, confirm_command);
-        }
-
-        debug!(
-            "Attempting to run command to confirm deployment: {}",
-            confirm_command
-        );
-
-        let ssh_confirm_exit_status = ssh_confirm_command
-            .arg(confirm_command)
-            .status()
-            .await
-            .map_err(DeployProfileError::SSHConfirmError)?;
-
-        match ssh_confirm_exit_status.code() {
-            Some(0) => (),
-            a => return Err(DeployProfileError::SSHConfirmExitError(a)),
-        };
-
-        info!("Deployment confirmed.");
-
+        let c = confirm_profile(deploy_data, deploy_defs, hostname, temp_path).await;
         recv_activated.await.unwrap();
+        c?;
     }
 
     Ok(())

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -323,6 +323,7 @@ pub async fn deploy_profile(
                 };
             },
             x = recv_activate => {
+                debug!("Activate command exited with an error");
                 return Err(x.unwrap());
             },
         }


### PR DESCRIPTION
We previously started and abandoned the `ssh_activate` SSH session, which would let it spill into our shells, and mean that `wait` always has to time out (`deploy` will never error due to `activate` encountering an error). This PR will let the `activate` session end before the `wait` session, which occurs if an activation error is encountered, it then handles the error (if any) correctly.

fixes #58 and fixes #49 (I think)