### PR TITLE
Fix. Remove ssh:// prefix from parametr ssh_activate and ssh_confirm …

### DIFF
--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -199,7 +199,7 @@ pub async fn deploy_profile(
         None => &deploy_data.node.node_settings.hostname,
     };
 
-    let ssh_addr = format!("ssh://{}@{}", deploy_defs.ssh_user, hostname);
+    let ssh_addr = format!("{}@{}", deploy_defs.ssh_user, hostname);
 
     let mut ssh_activate_command_ = Command::new("ssh");
     let ssh_activate_command = ssh_activate_command_.arg(&ssh_addr);
@@ -260,7 +260,7 @@ pub async fn deploy_profile(
         info!("Success activating, attempting to confirm activation");
 
         let mut c = Command::new("ssh");
-        let mut ssh_confirm_command = c.arg(format!("ssh://{}@{}", deploy_defs.ssh_user, hostname));
+        let mut ssh_confirm_command = c.arg(format!("{}@{}", deploy_defs.ssh_user, hostname));
 
         for ssh_opt in &deploy_data.merged_settings.ssh_opts {
             ssh_confirm_command = ssh_confirm_command.arg(ssh_opt);


### PR DESCRIPTION
Activate is trying connect with wrong user name. Build and "nix copy" steps are running fine. But Activate step is trying to connect with username "ssh".
Removing prefix ssh:// from ssh parameter fix it.