### PR TITLE
cd into `/tmp` during NixOS activation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,9 @@
             };
 
             nixos = base: custom base.config.system.build.toplevel ''
+              # work around https://github.com/NixOS/nixpkgs/issues/73404
+              cd /tmp
+
               $PROFILE/bin/switch-to-configuration switch
 
               # https://github.com/serokell/deploy-rs/issues/31


### PR DESCRIPTION
This should accomplish the same thing as https://github.com/serokell/deploy-rs/pull/39 but implemented slightly differently. Both are designed to work around NixOS/nixpkgs#73404, but this one sets the working directory inside the activation script, not the activation code.

The advantages of this method is we do not have the alter the functionality of deploy-rs, especially functionality we currently depend on (sadly) in many usages of deploy-rs. It is also fundamentally incorrect to make deploy-rs depend on the existence of `/tmp` in all contexts, and incorrect for deploy-rs internals to work around issues for specific deployment types, whereas instead this belongs in the deployment-type-specific logic in the `flake.nix` file (as has been changed here).

As correctly mentioned in discussion of the first PR, the method in this PR does have a disadvantage. This will only apply the patch to new deployments of NixOS, if activation fails and it rolls back to an older profile, that profile will not have this patch, and thus fail to activate. I don't see this as much of an issue personally, as for most people (i.e. anybody that didn't utilize the code in the previous PR), they will have never succesfully activated a profile affected by this issue, and for those who have, all they have to do is a single succesful activation, and this will no longer be a concern.