### PR TITLE
Fix examples/system/README.md: `deploy` -> `deploy-rs`

### DIFF
--- a/examples/system/README.md
+++ b/examples/system/README.md
@@ -11,6 +11,6 @@ This is an example of how to deploy a full nixos system with a separate user uni
 1. Run bare system from `.#nixosConfigurations.bare`
   - `nix build .#nixosConfigurations.bare.config.system.build.vm`
   - `QEMU_NET_OPTS=hostfwd=tcp::2221-:22 ./result/bin/run-bare-system-vm`
-2. `nix run github:serokell/deploy`
+2. `nix run github:serokell/deploy-rs`
 3. ???
 4. PROFIT!!!


### PR DESCRIPTION
I assume that the intention is to use `deploy-rs` and not its predecessor, or have I misunderstood?