### PR TITLE
Add helper activation function for home-manager

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -112,6 +112,8 @@
               "sed -i '/^default /d' ${efi.efiSysMountPoint}/loader/loader.conf"}
             '';
 
+            home-manager = base: custom base.activationPackage "$PROFILE/activate";
+
             noop = base: custom base ":";
           };
 


### PR DESCRIPTION
This resolves #43, though I would also like to add example usage, and we may want to change out `hm` for `home-manager`, I'm not sure what one is best