### PR TITLE
Mention the matrix channel in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ SPDX-License-Identifier: MPL-2.0
 
 A Simple, multi-profile Nix-flake deploy tool.
 
+Questions? Need help? Join us on Matrix: [`#deploy-rs:matrix.org`](https://matrix.to/#/#deploy-rs:matrix.org)
+
 ## Usage
 
 Basic usage: `deploy [options] <flake>`.


### PR DESCRIPTION
We now have a matrix channel. To increase community engagement, we should mention it in the README.
