### PR TITLE
Expand environmental variables in sshOpts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,7 @@ name = "deploy-rs"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "envmnt",
  "flexi_logger",
  "fork",
  "futures-util",
@@ -152,6 +153,16 @@ dependencies = [
  "toml",
  "whoami",
  "yn",
+]
+
+[[package]]
+name = "envmnt"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbfac51e9996e41d78a943227b7f313efcebf545b21584a0e213b956a062e11e"
+dependencies = [
+ "fsio",
+ "indexmap",
 ]
 
 [[package]]
@@ -209,6 +220,12 @@ checksum = "77a29c77f1ca394c3e73a9a5d24cfcabb734682d9634fc398f2204a63c994120"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "fsio"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a50045aa8931ae01afbc5d72439e8f57f326becb8c70d07dfc816778eff3d167"
 
 [[package]]
 name = "fuchsia-zircon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { version = "1.9.0", features = [ "full" ] }
 toml = "0.5"
 whoami = "0.9.0"
 yn = "0.1"
+envmnt = "0.9.0"
 
 # smol_str is required by rnix, but 0.1.17 doesn't build on rustc
 # 1.45.2 (shipped in nixos-20.09); it requires rustc 1.46.0. See


### PR DESCRIPTION
For now only bracket style expansion is enabled, i.e. `${MY_VAR}`. I had issues with expanding `$MY_VAR` in a path string, and so excluded that usecase to avoid errors. One can specify brackets in a Nix string by escaping the `$`, e.g. `"\${NOT_EXPANDED_BY_NIX}"`.