### PR TITLE
flake: replace naersk with buildRustPackage

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,27 +16,6 @@
         "type": "github"
       }
     },
-    "naersk": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1622810282,
-        "narHash": "sha256-4wmvM3/xfD0hCdNDIXVzRMfL4yB1J+DjH6Zte2xbAxk=",
-        "owner": "nmattia",
-        "repo": "naersk",
-        "rev": "e8061169e1495871b56be97c5c51d310fae01374",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nmattia",
-        "ref": "master",
-        "repo": "naersk",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1622972307,
@@ -56,7 +35,6 @@
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "naersk": "naersk",
         "nixpkgs": "nixpkgs",
         "utils": "utils"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,10 +8,6 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    naersk = {
-      url = "github:nmattia/naersk/master";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     utils.url = "github:numtide/flake-utils";
     flake-compat = {
       url = "github:edolstra/flake-compat";
@@ -19,11 +15,10 @@
     };
   };
 
-  outputs = { self, nixpkgs, utils, naersk, ... }:
+  outputs = { self, nixpkgs, utils, ... }:
   {
     overlay = final: prev:
     let
-      naersk-lib = final.callPackage naersk { };
       system = final.system;
       isDarwin = final.lib.strings.hasSuffix "-darwin" system;
       darwinOptions = final.lib.optionalAttrs isDarwin {
@@ -35,8 +30,13 @@
     {
       deploy-rs = {
 
-        deploy-rs = naersk-lib.buildPackage (darwinOptions // {
-          root = ./.;
+        deploy-rs = final.rustPlatform.buildRustPackage (darwinOptions // {
+          pname = "deploy-rs";
+          version = "0.1.0";
+
+          src = ./.;
+
+          cargoLock.lockFile = ./Cargo.lock;
         }) // { meta.description = "A Simple multi-profile Nix-flake deploy tool"; };
 
         lib = rec {


### PR DESCRIPTION
We weren't using any features of naersk that weren't covered by
buildRustPackage, so let's just use the tooling already in nixpkgs for Rust
builds and get rid of a flake input.
