### PR TITLE
Add custom sudo command support

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ This is a set of options that can be put in any of the above definitions, with t
   # If `sshUser` is specified, this will be the default (though it will _not_ default to your own username)
   user = "root";
 
+  # Which sudo command to use. Must accept at least two arguments:
+  # the user name to execute commands as and the rest is the command to execute
+  # This will default to "sudo -u" if not specified anywhere.
+  sudo = "doas -u";
+
   # This is an optional list of arguments that will be passed to SSH.
   sshOpts = [ "-p" "2121" ];
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -89,6 +89,9 @@ pub struct Opts {
     /// Revoke all previously succeeded deploys when deploying multiple profiles
     #[clap(long)]
     rollback_succeeded: Option<bool>,
+    /// Which sudo command to use. Must accept at least two arguments: user name to execute commands as and the rest is the command to execute
+    #[clap(long)]
+    sudo: Option<String>,
 }
 
 /// Returns if the available Nix installation supports flakes
@@ -635,6 +638,7 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
         temp_path: opts.temp_path,
         confirm_timeout: opts.confirm_timeout,
         dry_activate: opts.dry_activate,
+        sudo: opts.sudo,
     };
 
     let supports_flakes = test_flake_support().await.map_err(RunError::FlakeTest)?;

--- a/src/data.rs
+++ b/src/data.rs
@@ -28,6 +28,8 @@ pub struct GenericSettings {
     pub temp_path: Option<String>,
     #[serde(rename(deserialize = "magicRollback"))]
     pub magic_rollback: Option<bool>,
+    #[serde(rename(deserialize = "sudo"))]
+    pub sudo: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,7 @@ pub struct CmdOverrides {
     pub magic_rollback: Option<bool>,
     pub temp_path: Option<String>,
     pub confirm_timeout: Option<u16>,
+    pub sudo: Option<String>,
     pub dry_activate: bool,
 }
 
@@ -350,7 +351,7 @@ impl<'a> DeployData<'a> {
         let profile_path = self.get_profile_path()?;
 
         let sudo: Option<String> = match self.merged_settings.user {
-            Some(ref user) if user != &ssh_user => Some(format!("sudo -u {}", user)),
+            Some(ref user) if user != &ssh_user => Some(format!("{} {}", self.get_sudo(), user)),
             _ => None,
         };
 
@@ -391,6 +392,13 @@ impl<'a> DeployData<'a> {
             },
         };
         Ok(profile_user)
+    }
+
+    fn get_sudo(&'a self) -> String {
+        return match self.merged_settings.sudo {
+           Some(ref x) => x.clone(),
+           None => "sudo -u".to_string()
+        };
     }
 }
 


### PR DESCRIPTION
This is useful for nodes that utilize `doas` instead of `sudo`.

---

This is my first rust anything, so I'm not sure if any of this is correct (or if I can write unit tests).

I need to add documentation still as well, but getting it up in case my rust is bad was my first priority.

Closes #145 