### PR TITLE
Build every profile first, then push

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -539,18 +539,27 @@ async fn run_deploy(
         print_deployment(&parts[..])?;
     }
 
-    for (deploy_flake, deploy_data, deploy_defs) in &parts {
-        deploy::push::push_profile(deploy::push::PushProfileData {
-            supports_flakes,
-            check_sigs,
-            repo: deploy_flake.repo,
-            deploy_data,
-            deploy_defs,
-            keep_result,
-            result_path,
-            extra_build_args,
-        })
-        .await?;
+    let data_iter = || {
+        parts.iter().map(
+            |(deploy_flake, deploy_data, deploy_defs)| deploy::push::PushProfileData {
+                supports_flakes,
+                check_sigs,
+                repo: deploy_flake.repo,
+                deploy_data,
+                deploy_defs,
+                keep_result,
+                result_path,
+                extra_build_args,
+            },
+        )
+    };
+
+    for data in data_iter() {
+        deploy::push::build_profile(data).await?;
+    }
+
+    for data in data_iter() {
+        deploy::push::push_profile(data).await?;
     }
 
     let mut succeeded: Vec<(&deploy::DeployData, &deploy::DeployDefs)> = vec![];

--- a/src/push.rs
+++ b/src/push.rs
@@ -54,7 +54,7 @@ pub struct PushProfileData<'a> {
     pub extra_build_args: &'a [String],
 }
 
-pub async fn push_profile(data: PushProfileData<'_>) -> Result<(), PushProfileError> {
+pub async fn build_profile(data: PushProfileData<'_>) -> Result<(), PushProfileError> {
     debug!(
         "Finding the deriver of store path for {}",
         &data.deploy_data.profile.profile_settings.path
@@ -180,6 +180,10 @@ pub async fn push_profile(data: PushProfileData<'_>) -> Result<(), PushProfileEr
         };
     }
 
+    Ok(())
+}
+
+pub async fn push_profile(data: PushProfileData<'_>) -> Result<(), PushProfileError> {
     info!(
         "Copying profile `{}` to node `{}`",
         data.deploy_data.profile_name, data.deploy_data.node_name


### PR DESCRIPTION
Try to build everything first before pushing to remotes. Since the build
is more likely to fail than the upload, if there is an error the deployment
will fail sooner and before uploading any potentially unusable configuration.