### PR TITLE
Update flake to support nix 2.8

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,7 +74,7 @@
                             name = base.name + "-activate-rs";
                             text = ''
                             #!${final.runtimeShell}
-                            exec ${self.defaultPackage.${system}}/bin/activate "$@"
+                            exec ${self.packages.${system}.default}/bin/activate "$@"
                           '';
                           executable = true;
                           destination = "/activate-rs";
@@ -133,12 +133,14 @@
       in
       {
         defaultPackage = self.packages."${system}".deploy-rs;
+        packages.default = self.packages."${system}".deploy-rs;
         packages.deploy-rs = pkgs.deploy-rs.deploy-rs;
 
         defaultApp = self.apps."${system}".deploy-rs;
+        apps.default = self.apps."${system}".deploy-rs;
         apps.deploy-rs = {
           type = "app";
-          program = "${self.defaultPackage."${system}"}/bin/deploy";
+          program = "${self.packages."${system}".default}/bin/deploy";
         };
 
         devShell = pkgs.mkShell {
@@ -157,7 +159,7 @@
         };
 
         checks = {
-          deploy-rs = self.defaultPackage.${system}.overrideAttrs (super: { doCheck = true; });
+          deploy-rs = self.packages.${system}.default.overrideAttrs (super: { doCheck = true; });
         };
 
         lib = pkgs.deploy-rs.lib;


### PR DESCRIPTION
Nix 2.7 [renamed defaultApp and defaultPackage](https://discourse.nixos.org/t/nix-2-7-0-released/18072). Both the old and new names are supported in 2.7, but 2.8 has removed support for the old names, breaking the `nix run github:serokell/deploy-rs .` invocation.

Old names are kept in this PR to keep compatibility with nix 2.6, but could be removed if support of this version is not needed anymore.

PR tested with 2.6.1, 2.7.0 and 2.8.0