### PR TITLE
Add option to build on the target host

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ This is a set of options that can be put in any of the above definitions, with t
   # If not specified, this will default to `/tmp`
   # (if `magicRollback` is in use, this _must_ be writable by `user`)
   tempPath = "/home/someuser/.deploy-rs";
+
+  # Build the derivation on the target system. 
+  # Will also fetch all external dependencies from the target system's substituters.
+  # This default to `false`
+  remoteBuild = true;
 }
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -56,6 +56,10 @@ pub struct Opts {
     #[clap(short, long)]
     skip_checks: bool,
 
+    /// Build on remote host
+    #[clap(long)]
+    remote_build: bool,
+
     /// Override the SSH user with the given value
     #[clap(long)]
     ssh_user: Option<String>,
@@ -138,9 +142,7 @@ async fn check_deployment(
                 .arg(format!("let r = import {}/.; x = (if builtins.isFunction r then (r {{}}) else r); in if x ? checks then x.checks.${{builtins.currentSystem}} else {{}}", repo));
     }
 
-    for extra_arg in extra_build_args {
-        check_command.arg(extra_arg);
-    }
+    check_command.args(extra_build_args);
 
     let check_status = check_command.status().await?;
 
@@ -239,9 +241,7 @@ async fn get_deployment_data(
             .arg(format!("let r = import {}/.; in if builtins.isFunction r then (r {{}}).deploy else r.deploy", flake.repo))
     };
 
-    for extra_arg in extra_build_args {
-        c.arg(extra_arg);
-    }
+    c.args(extra_build_args);
 
     let build_child = c
         .stdout(Stdio::piped())
@@ -640,6 +640,7 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
         temp_path: opts.temp_path,
         confirm_timeout: opts.confirm_timeout,
         dry_activate: opts.dry_activate,
+        remote_build: opts.remote_build,
         sudo: opts.sudo,
     };
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -30,6 +30,8 @@ pub struct GenericSettings {
     pub magic_rollback: Option<bool>,
     #[serde(rename(deserialize = "sudo"))]
     pub sudo: Option<String>,
+    #[serde(default,rename(deserialize = "remoteBuild"))]
+    pub remote_build: Option<bool>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,7 @@ pub struct CmdOverrides {
     pub confirm_timeout: Option<u16>,
     pub sudo: Option<String>,
     pub dry_activate: bool,
+    pub remote_build: bool,
 }
 
 #[derive(PartialEq, Debug)]
@@ -395,10 +396,10 @@ impl<'a> DeployData<'a> {
     }
 
     fn get_sudo(&'a self) -> String {
-        return match self.merged_settings.sudo {
-           Some(ref x) => x.clone(),
-           None => "sudo -u".to_string()
-        };
+        match self.merged_settings.sudo {
+            Some(ref x) => x.clone(),
+            None => "sudo -u".to_string(),
+        }
     }
 }
 
@@ -416,6 +417,10 @@ pub fn make_deploy_data<'a, 's>(
     merged_settings.merge(node.generic_settings.clone());
     merged_settings.merge(top_settings.clone());
 
+    // build all machines remotely when the command line flag is set
+    if cmd_overrides.remote_build {
+        merged_settings.remote_build = Some(cmd_overrides.remote_build);
+    }
     if cmd_overrides.ssh_user.is_some() {
         merged_settings.ssh_user = cmd_overrides.ssh_user.clone();
     }


### PR DESCRIPTION
This PR adds the option to build the derivation on the target server instead of locally.
The derivation will first be uploaded to the target system and then built in the remote store.
Any required external dependencies will be fetched to the target host using the target system's substituters.

Fixes #12 