### PR TITLE
Add new activation strategy `boot` as equivalent to `nixos-rebuild boot`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,9 @@
                             if [[ "''${DRY_ACTIVATE:-}" == "1" ]]
                             then
                                 ${customSelf.dryActivate or "echo ${final.writeScript "activate" activate}"}
+                            elif [[ "''${BOOT:-}" == "1" ]]
+                            then
+                                ${customSelf.boot or "echo ${final.writeScript "activate" activate}"}
                             else
                                 ${activate}
                             fi
@@ -83,17 +86,23 @@
                   };
               };
 
-            nixos = base: (custom // { dryActivate = "$PROFILE/bin/switch-to-configuration dry-activate"; }) base.config.system.build.toplevel ''
-              # work around https://github.com/NixOS/nixpkgs/issues/73404
-              cd /tmp
+            nixos = base:
+              (custom // {
+                dryActivate = "$PROFILE/bin/switch-to-configuration dry-activate";
+                boot = "$PROFILE/bin/switch-to-configuration boot";
+              })
+              base.config.system.build.toplevel
+              ''
+                # work around https://github.com/NixOS/nixpkgs/issues/73404
+                cd /tmp
 
-              $PROFILE/bin/switch-to-configuration switch
+                $PROFILE/bin/switch-to-configuration switch
 
-              # https://github.com/serokell/deploy-rs/issues/31
-              ${with base.config.boot.loader;
-              final.lib.optionalString systemd-boot.enable
-              "sed -i '/^default /d' ${efi.efiSysMountPoint}/loader/loader.conf"}
-            '';
+                # https://github.com/serokell/deploy-rs/issues/31
+                ${with base.config.boot.loader;
+                final.lib.optionalString systemd-boot.enable
+                "sed -i '/^default /d' ${efi.efiSysMountPoint}/loader/loader.conf"}
+              '';
 
             home-manager = base: custom base.activationPackage "$PROFILE/activate";
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -86,6 +86,9 @@ pub struct Opts {
     /// Show what will be activated on the machines
     #[clap(long)]
     dry_activate: bool,
+    /// Don't activate, but update the boot loader to boot into the new profile
+    #[clap(long)]
+    boot: bool,
     /// Revoke all previously succeeded deploys when deploying multiple profiles
     #[clap(long)]
     rollback_succeeded: Option<bool>,
@@ -409,6 +412,7 @@ async fn run_deploy(
     extra_build_args: &[String],
     debug_logs: bool,
     dry_activate: bool,
+    boot: bool,
     log_dir: &Option<String>,
     rollback_succeeded: bool,
 ) -> Result<(), RunDeployError> {
@@ -560,7 +564,7 @@ async fn run_deploy(
     // Rollbacks adhere to the global seeting to auto_rollback and secondary
     // the profile's configuration
     for (_, deploy_data, deploy_defs) in &parts {
-        if let Err(e) = deploy::deploy::deploy_profile(deploy_data, deploy_defs, dry_activate).await
+        if let Err(e) = deploy::deploy::deploy_profile(deploy_data, deploy_defs, dry_activate, boot).await
         {
             error!("{}", e);
             if dry_activate {
@@ -617,6 +621,10 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
         &deploy::LoggerType::Deploy,
     )?;
 
+    if opts.dry_activate && opts.boot {
+        error!("Cannot use both --dry-activate & --boot!");
+    }
+
     let deploys = opts
         .clone()
         .targets
@@ -666,6 +674,7 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
         &opts.extra_build_args,
         opts.debug_logs,
         opts.dry_activate,
+        opts.boot,
         &opts.log_dir,
         opts.rollback_succeeded.unwrap_or(true),
     )


### PR DESCRIPTION
This can be useful when e.g. deploying a kernel update to a target host. You usually plan a reboot (or kexec) after that to activate the new kernel. However you don't want to wait for services to be restarted first since these will be "restarted" anyways on the reboot. In cases like GitLab or the Atlassian stack this actually makes a difference.

This patch changes the following things:

* If `--boot` is provided, `nix-env -p profile-to-activate --set` is called for each deployed profile to make sure that it is activated automatically after a reboot.

* However, the actual activation (e.g. `switch-to-configuration switch`) is skipped. Instead:

  * For NixOS, `switch-to-configuration boot` is called to set the new profile as default in the bootloader.

  * For everything else, nothing else is done. The profile is already the new default (and thus picked up on the next boot).

cc @balsoft 