### PR TITLE
Make it possible to not rebuild deploy-rs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
                             name = base.name + "-activate-rs";
                             text = ''
                             #!${final.runtimeShell}
-                            exec ${self.packages.${system}.default}/bin/activate "$@"
+                            exec ${final.deploy-rs.deploy-rs}/bin/activate "$@"
                           '';
                           executable = true;
                           destination = "/activate-rs";


### PR DESCRIPTION
Use the deploy-rs from the final packages set. This can avoid rebuilding deploy-rs when using it in a nixos config. It can use the version cached in nixpkgs.

Also add instructions to the readme on how to craft an overlay that uses nixpkgs deploy-rs.

This should fix #163.