### PR TITLE
Add extra-ssh-opts flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,6 +70,9 @@ pub struct Opts {
     /// Override the SSH options used
     #[clap(long)]
     ssh_opts: Option<String>,
+    /// Additional SSH options to be used
+    #[clap(long)]
+    extra_ssh_opts: Option<String>,
     /// Override if the connecting to the target node should be considered fast
     #[clap(long)]
     fast_connection: Option<bool>,
@@ -651,6 +654,7 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
         ssh_user: opts.ssh_user,
         profile_user: opts.profile_user,
         ssh_opts: opts.ssh_opts,
+        extra_ssh_opts: opts.extra_ssh_opts,
         fast_connection: opts.fast_connection,
         auto_rollback: opts.auto_rollback,
         hostname: opts.hostname,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,7 @@ pub struct CmdOverrides {
     pub ssh_user: Option<String>,
     pub profile_user: Option<String>,
     pub ssh_opts: Option<String>,
+    pub extra_ssh_opts: Option<String>,
     pub fast_connection: Option<bool>,
     pub auto_rollback: Option<bool>,
     pub hostname: Option<String>,
@@ -431,6 +432,16 @@ pub fn make_deploy_data<'a, 's>(
     }
     if let Some(ref ssh_opts) = cmd_overrides.ssh_opts {
         merged_settings.ssh_opts = ssh_opts.split(' ').map(|x| x.to_owned()).collect();
+    }
+    if let Some(ref extra_ssh_opts) = cmd_overrides.extra_ssh_opts {
+        let mut ssh_opts = merged_settings.ssh_opts;
+        ssh_opts.extend(
+            extra_ssh_opts
+                .split(' ')
+                .map(|x| x.to_owned())
+                .collect::<Vec<String>>(),
+        );
+        merged_settings.ssh_opts = ssh_opts;
     }
     if let Some(fast_connection) = cmd_overrides.fast_connection {
         merged_settings.fast_connection = Some(fast_connection);


### PR DESCRIPTION
This is useful in situations when there's a need to pass on extra ssh client options, e.g. in CI pipeline to set different hostname, port (VPN requiring different hostnames) without overriding options set in deploy configuration.