### PR TITLE
flake: switch to `hercules-ci/flake-parts`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -16,13 +16,30 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1690933134,
+        "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671417167,
-        "narHash": "sha256-JkHam6WQOwZN1t2C2sbp1TqMv3TVRjzrdoejqfefwrM=",
+        "lastModified": 1691683125,
+        "narHash": "sha256-FMU62G57HDbJwU+9V3q7I0mBaQYTYQdtPNlJt2t5/A4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bb31220cca6d044baa6dc2715b07497a2a7c4bc7",
+        "rev": "4d2389b927696ef8da4ef76b03f2d306faf87929",
         "type": "github"
       },
       "original": {
@@ -32,25 +49,44 @@
         "type": "github"
       }
     },
-    "root": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "nixpkgs": "nixpkgs",
-        "utils": "utils"
-      }
-    },
-    "utils": {
+    "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "dir": "lib",
+        "lastModified": 1690881714,
+        "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e1960bc196baf6881340d53dccb203a951745a2",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -8,176 +8,185 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    utils.url = "github:numtide/flake-utils";
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
     };
+    systems.url = "github:nix-systems/default";
   };
 
-  outputs = { self, nixpkgs, utils, ... }:
-  {
-    overlay = final: prev:
-    let
-      system = final.stdenv.hostPlatform.system;
-      darwinOptions = final.lib.optionalAttrs final.stdenv.isDarwin {
-        buildInputs = with final.darwin.apple_sdk.frameworks; [
-          SystemConfiguration
-          CoreServices
+  outputs = inputs@{ self, flake-parts, systems, ... }: flake-parts.lib.mkFlake { inherit inputs; } {
+    systems = import systems;
+
+    perSystem = { config, self', inputs', pkgs, system, lib, ... }: {
+      _module.args.pkgs = import inputs.nixpkgs {
+        inherit system;
+        overlays = [
+          self.overlay
         ];
       };
-    in
-    {
-      deploy-rs = {
 
-        deploy-rs = final.rustPlatform.buildRustPackage (darwinOptions // {
-          pname = "deploy-rs";
-          version = "0.1.0";
+      formatter = pkgs.nixpkgs-fmt;
 
-          src = ./.;
+      packages.default = self'.packages.deploy-rs;
+      packages.deploy-rs = pkgs.deploy-rs.deploy-rs;
 
-          cargoLock.lockFile = ./Cargo.lock;
-        }) // { meta.description = "A Simple multi-profile Nix-flake deploy tool"; };
+      apps.default = self'.apps.deploy-rs;
+      apps.deploy-rs = {
+        type = "app";
+        program = lib.getExe self'.packages.default;
+      };
 
-        lib = rec {
+      devShells.default = pkgs.mkShell {
+        inputsFrom = [ self'.packages.deploy-rs ];
+        RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+        buildInputs = with pkgs; [
+          nixUnstable
+          cargo
+          rustc
+          rust-analyzer
+          rustfmt
+          clippy
+          reuse
+          rust.packages.stable.rustPlatform.rustLibSrc
+        ];
+      };
 
-          setActivate = builtins.trace
-            "deploy-rs#lib.setActivate is deprecated, use activate.noop, activate.nixos or activate.custom instead"
-            activate.custom;
-
-          activate = rec {
-            custom =
-              {
-                __functor = customSelf: base: activate:
-                  final.buildEnv {
-                    name = ("activatable-" + base.name);
-                    paths =
-                      [
-                        base
-                        (final.writeTextFile {
-                          name = base.name + "-activate-path";
-                          text = ''
-                            #!${final.runtimeShell}
-                            set -euo pipefail
-
-                            if [[ "''${DRY_ACTIVATE:-}" == "1" ]]
-                            then
-                                ${customSelf.dryActivate or "echo ${final.writeScript "activate" activate}"}
-                            elif [[ "''${BOOT:-}" == "1" ]]
-                            then
-                                ${customSelf.boot or "echo ${final.writeScript "activate" activate}"}
-                            else
-                                ${activate}
-                            fi
-                          '';
-                          executable = true;
-                          destination = "/deploy-rs-activate";
-                        })
-                        (final.writeTextFile {
-                            name = base.name + "-activate-rs";
-                            text = ''
-                            #!${final.runtimeShell}
-                            exec ${final.deploy-rs.deploy-rs}/bin/activate "$@"
-                          '';
-                          executable = true;
-                          destination = "/activate-rs";
-                        })
-                      ];
-                  };
-              };
-
-            nixos = base:
-              (custom // {
-                dryActivate = "$PROFILE/bin/switch-to-configuration dry-activate";
-                boot = "$PROFILE/bin/switch-to-configuration boot";
-              })
-              base.config.system.build.toplevel
-              ''
-                # work around https://github.com/NixOS/nixpkgs/issues/73404
-                cd /tmp
-
-                $PROFILE/bin/switch-to-configuration switch
-
-                # https://github.com/serokell/deploy-rs/issues/31
-                ${with base.config.boot.loader;
-                final.lib.optionalString systemd-boot.enable
-                "sed -i '/^default /d' ${efi.efiSysMountPoint}/loader/loader.conf"}
-              '';
-
-            home-manager = base: custom base.activationPackage "$PROFILE/activate";
-
-            # Activation script for 'darwinSystem' from nix-darwin.
-            # 'HOME=/var/root' is needed because 'sudo' on darwin doesn't change 'HOME' directory,
-            # while 'darwin-rebuild' (which is invoked under the hood) performs some nix-channel
-            # checks that rely on 'HOME'. As a result, if 'sshUser' is different from root,
-            # deployment may fail without explicit 'HOME' redefinition.
-            darwin = base: custom base.config.system.build.toplevel "HOME=/var/root $PROFILE/activate";
-
-            noop = base: custom base ":";
-          };
-
-          deployChecks = deploy: builtins.mapAttrs (_: check: check deploy) {
-            deploy-schema = deploy: final.runCommand "jsonschema-deploy-system" { } ''
-              ${final.python3.pkgs.jsonschema}/bin/jsonschema -i ${final.writeText "deploy.json" (builtins.toJSON deploy)} ${./interface.json} && touch $out
-            '';
-
-            deploy-activate = deploy:
-              let
-                profiles = builtins.concatLists (final.lib.mapAttrsToList (nodeName: node: final.lib.mapAttrsToList (profileName: profile: [ (toString profile.path) nodeName profileName ]) node.profiles) deploy.nodes);
-              in
-              final.runCommand "deploy-rs-check-activate" { } ''
-                for x in ${builtins.concatStringsSep " " (map (p: builtins.concatStringsSep ":" p) profiles)}; do
-                  profile_path=$(echo $x | cut -f1 -d:)
-                  node_name=$(echo $x | cut -f2 -d:)
-                  profile_name=$(echo $x | cut -f3 -d:)
-
-                  test -f "$profile_path/deploy-rs-activate" || (echo "#$node_name.$profile_name is missing the deploy-rs-activate activation script" && exit 1);
-
-                  test -f "$profile_path/activate-rs" || (echo "#$node_name.$profile_name is missing the activate-rs activation script" && exit 1);
-                done
-
-                touch $out
-              '';
-          };
-        };
+      checks = {
+        deploy-rs = self'.packages.default.overrideAttrs (super: { doCheck = true; });
       };
     };
-  } //
-    utils.lib.eachSystem (utils.lib.defaultSystems ++ ["aarch64-darwin"]) (system:
-      let
-        pkgs = import nixpkgs { inherit system; overlays = [ self.overlay ]; };
-      in
-      {
-        defaultPackage = self.packages."${system}".deploy-rs;
-        packages.default = self.packages."${system}".deploy-rs;
-        packages.deploy-rs = pkgs.deploy-rs.deploy-rs;
 
-        defaultApp = self.apps."${system}".deploy-rs;
-        apps.default = self.apps."${system}".deploy-rs;
-        apps.deploy-rs = {
-          type = "app";
-          program = "${self.packages."${system}".default}/bin/deploy";
+    flake = {
+      overlays.default = self.overlay;
+      overlay = final: prev:
+        let
+          darwinOptions = final.lib.optionalAttrs final.stdenv.isDarwin {
+            buildInputs = with final.darwin.apple_sdk.frameworks; [
+              SystemConfiguration
+              CoreServices
+            ];
+          };
+        in
+        {
+          deploy-rs = {
+
+            deploy-rs = final.rustPlatform.buildRustPackage
+              (darwinOptions // {
+                pname = "deploy-rs";
+                version = "0.1.0";
+
+                src = ./.;
+
+                cargoLock.lockFile = ./Cargo.lock;
+              }) // {
+                meta.description = "A Simple multi-profile Nix-flake deploy tool";
+                meta.mainProgram = "deploy";
+              };
+
+            lib = rec {
+
+              setActivate = builtins.trace
+                "deploy-rs#lib.setActivate is deprecated, use activate.noop, activate.nixos or activate.custom instead"
+                activate.custom;
+
+              activate = rec {
+                custom =
+                  {
+                    __functor = customSelf: base: activate:
+                      final.buildEnv {
+                        name = ("activatable-" + base.name);
+                        paths =
+                          [
+                            base
+                            (final.writeTextFile {
+                              name = base.name + "-activate-path";
+                              text = ''
+                                #!${final.runtimeShell}
+                                set -euo pipefail
+
+                                if [[ "''${DRY_ACTIVATE:-}" == "1" ]]
+                                then
+                                    ${customSelf.dryActivate or "echo ${final.writeScript "activate" activate}"}
+                                elif [[ "''${BOOT:-}" == "1" ]]
+                                then
+                                    ${customSelf.boot or "echo ${final.writeScript "activate" activate}"}
+                                else
+                                    ${activate}
+                                fi
+                              '';
+                              executable = true;
+                              destination = "/deploy-rs-activate";
+                            })
+                            (final.writeTextFile {
+                              name = base.name + "-activate-rs";
+                              text = ''
+                                #!${final.runtimeShell}
+                                exec ${final.deploy-rs.deploy-rs}/bin/activate "$@"
+                              '';
+                              executable = true;
+                              destination = "/activate-rs";
+                            })
+                          ];
+                      };
+                  };
+
+                nixos = base:
+                  (custom // {
+                    dryActivate = "$PROFILE/bin/switch-to-configuration dry-activate";
+                    boot = "$PROFILE/bin/switch-to-configuration boot";
+                  })
+                    base.config.system.build.toplevel
+                    ''
+                      # work around https://github.com/NixOS/nixpkgs/issues/73404
+                      cd /tmp
+
+                      $PROFILE/bin/switch-to-configuration switch
+
+                      # https://github.com/serokell/deploy-rs/issues/31
+                      ${with base.config.boot.loader;
+                      final.lib.optionalString systemd-boot.enable
+                      "sed -i '/^default /d' ${efi.efiSysMountPoint}/loader/loader.conf"}
+                    '';
+
+                home-manager = base: custom base.activationPackage "$PROFILE/activate";
+
+                # Activation script for 'darwinSystem' from nix-darwin.
+                # 'HOME=/var/root' is needed because 'sudo' on darwin doesn't change 'HOME' directory,
+                # while 'darwin-rebuild' (which is invoked under the hood) performs some nix-channel
+                # checks that rely on 'HOME'. As a result, if 'sshUser' is different from root,
+                # deployment may fail without explicit 'HOME' redefinition.
+                darwin = base: custom base.config.system.build.toplevel "HOME=/var/root $PROFILE/activate";
+
+                noop = base: custom base ":";
+              };
+
+              deployChecks = deploy: builtins.mapAttrs (_: check: check deploy) {
+                deploy-schema = deploy: final.runCommand "jsonschema-deploy-system" { } ''
+                  ${final.python3.pkgs.jsonschema}/bin/jsonschema -i ${final.writeText "deploy.json" (builtins.toJSON deploy)} ${./interface.json} && touch $out
+                '';
+
+                deploy-activate = deploy:
+                  let
+                    profiles = builtins.concatLists (final.lib.mapAttrsToList (nodeName: node: final.lib.mapAttrsToList (profileName: profile: [ (toString profile.path) nodeName profileName ]) node.profiles) deploy.nodes);
+                  in
+                  final.runCommand "deploy-rs-check-activate" { } ''
+                    for x in ${builtins.concatStringsSep " " (map (p: builtins.concatStringsSep ":" p) profiles)}; do
+                      profile_path=$(echo $x | cut -f1 -d:)
+                      node_name=$(echo $x | cut -f2 -d:)
+                      profile_name=$(echo $x | cut -f3 -d:)
+
+                      test -f "$profile_path/deploy-rs-activate" || (echo "#$node_name.$profile_name is missing the deploy-rs-activate activation script" && exit 1);
+
+                      test -f "$profile_path/activate-rs" || (echo "#$node_name.$profile_name is missing the activate-rs activation script" && exit 1);
+                    done
+
+                    touch $out
+                  '';
+              };
+            };
+          };
         };
-
-        devShell = pkgs.mkShell {
-          inputsFrom = [ self.packages.${system}.deploy-rs ];
-          RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
-          buildInputs = with pkgs; [
-            nixUnstable
-            cargo
-            rustc
-            rust-analyzer
-            rustfmt
-            clippy
-            reuse
-            rust.packages.stable.rustPlatform.rustLibSrc
-          ];
-        };
-
-        checks = {
-          deploy-rs = self.packages.${system}.default.overrideAttrs (super: { doCheck = true; });
-        };
-
-        lib = pkgs.deploy-rs.lib;
-      });
+    };
+  };
 }


### PR DESCRIPTION
Hi,

I have been working with Deploy RS for some time now. Recently, I noticed an opportunity to modernize the `flake.nix` file.

The modifications I've made primarily focus on switching from [`numtide/flake-utils`](https://github.com/numtide/flake-utils) to [`hercules-ci/flake-parts`](https://flake.parts/).

If these modifications align with your vision for the project, I would be honored to see them implemented. Of course, I am open to any feedback and willing to make further adjustments as needed.
