### PR TITLE
Replace jsonschema-cli with check-jsonschema

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -118,7 +118,7 @@
 
           deployChecks = deploy: builtins.mapAttrs (_: check: check deploy) {
             deploy-schema = deploy: final.runCommand "jsonschema-deploy-system" { } ''
-              ${final.python3.pkgs.jsonschema}/bin/jsonschema -i ${final.writeText "deploy.json" (builtins.toJSON deploy)} ${./interface.json} && touch $out
+              ${final.check-jsonschema}/bin/check-jsonschema --schemafile ${./interface.json} ${final.writeText "deploy.json" (builtins.toJSON deploy)} && touch $out
             '';
 
             deploy-activate = deploy:


### PR DESCRIPTION
`jsonschema-cli` is deprecated and will be removed in the future. The recommended replacement is `check-jsonschema`.

I tested the changes with my setup, the new cli gives a positive validation result on stdout.