### PR TITLE
[Chore] Run CI checks on 'pull_request'

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,5 +1,5 @@
 name: Nix flake check
-on: push
+on: pull_request
 
 jobs:
   check:


### PR DESCRIPTION
Problem: We want to be able to run CI checks on PRs from external forks.
However, this is only possible with 'on: pull_request', while currently
CI is triggered 'on: push'

Solution: Change CI triggering condition to 'on: pull_request'.