### PR TITLE
Add a flag for building configuration with nix-output-monitor

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -100,6 +100,9 @@ pub struct Opts {
     /// Which sudo command to use. Must accept at least two arguments: user name to execute commands as and the rest is the command to execute
     #[clap(long)]
     sudo: Option<String>,
+    /// Call nom (nix-output-monitor) when building the configuration.
+    #[clap(long)]
+    nom: bool,
 }
 
 /// Returns if the available Nix installation supports flakes
@@ -418,6 +421,7 @@ async fn run_deploy(
     boot: bool,
     log_dir: &Option<String>,
     rollback_succeeded: bool,
+    use_nom: bool,
 ) -> Result<(), RunDeployError> {
     let to_deploy: ToDeploy = deploy_flakes
         .iter()
@@ -557,6 +561,7 @@ async fn run_deploy(
                 keep_result,
                 result_path,
                 extra_build_args,
+                use_nom,
             },
         )
     };
@@ -690,6 +695,7 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
         opts.boot,
         &opts.log_dir,
         opts.rollback_succeeded.unwrap_or(true),
+        opts.nom,
     )
     .await?;
 

--- a/src/push.rs
+++ b/src/push.rs
@@ -57,6 +57,7 @@ pub struct PushProfileData<'a> {
     pub keep_result: bool,
     pub result_path: Option<&'a str>,
     pub extra_build_args: &'a [String],
+    pub use_nom: bool,
 }
 
 pub async fn build_profile_locally(data: &PushProfileData<'_>, derivation_name: &str) -> Result<(), PushProfileError> {
@@ -66,9 +67,9 @@ pub async fn build_profile_locally(data: &PushProfileData<'_>, derivation_name: 
     );
 
     let mut build_command = if data.supports_flakes {
-        Command::new("nix")
+        Command::new(if data.use_nom {"nom"} else {"nix"})
     } else {
-        Command::new("nix-build")
+        Command::new(if data.use_nom {"nom-build"} else {"nix-build"})
     };
 
     if data.supports_flakes {
@@ -184,7 +185,7 @@ pub async fn build_profile_remotely(data: &PushProfileData<'_>, derivation_name:
         a => return Err(PushProfileError::CopyExit(a)),
     };
 
-    let mut build_command = Command::new("nix");
+    let mut build_command = Command::new(if data.use_nom {"nom"} else {"nix"});
     build_command
         .arg("build").arg(derivation_name)
         .arg("--eval-store").arg("auto")


### PR DESCRIPTION
I like using the [nix-output-monitor](https://github.com/maralorn/nix-output-monitor) for my builds sometimes, so I added a `--nom` flag to `deploy` to make it call `nom` instead of `nix` when building the system configuration.

This is a pretty bare-bones change (e.g. it does not check if `nom` is actually present on the `$PATH`, though this could be added), and I'm not sure if you're interested in such a feature for `deploy-rs` in the first place — but I thought I'd leave this PR here in case it's useful to you.