### PR TITLE
[Chore] Make activation wait timeout configurable

### DIFF
--- a/interface.json
+++ b/interface.json
@@ -30,6 +30,9 @@
                 "confirmTimeout": {
                     "type": "integer"
                 },
+                "activationTimeout": {
+                    "type": "integer"
+                },
                 "tempPath": {
                     "type": "string"
                 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -85,6 +85,9 @@ pub struct Opts {
     /// How long activation should wait for confirmation (if using magic-rollback)
     #[clap(long)]
     confirm_timeout: Option<u16>,
+    /// How long we should wait for profile activation (if using magic-rollback)
+    #[clap(long)]
+    activation_timeout: Option<u16>,
     /// Where to store temporary files (only used by magic-rollback)
     #[clap(long)]
     temp_path: Option<PathBuf>,
@@ -658,6 +661,7 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
         magic_rollback: opts.magic_rollback,
         temp_path: opts.temp_path,
         confirm_timeout: opts.confirm_timeout,
+        activation_timeout: opts.activation_timeout,
         dry_activate: opts.dry_activate,
         remote_build: opts.remote_build,
         sudo: opts.sudo,

--- a/src/data.rs
+++ b/src/data.rs
@@ -25,6 +25,8 @@ pub struct GenericSettings {
     pub auto_rollback: Option<bool>,
     #[serde(rename(deserialize = "confirmTimeout"))]
     pub confirm_timeout: Option<u16>,
+    #[serde(rename(deserialize = "activationTimeout"))]
+    pub activation_timeout: Option<u16>,
     #[serde(rename(deserialize = "tempPath"))]
     pub temp_path: Option<PathBuf>,
     #[serde(rename(deserialize = "magicRollback"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,7 +446,7 @@ pub fn make_deploy_data<'a, 's>(
         merged_settings.confirm_timeout = Some(confirm_timeout);
     }
     if let Some(activation_timeout) = cmd_overrides.activation_timeout {
-        merged_settings.confirm_timeout = Some(activation_timeout);
+        merged_settings.activation_timeout = Some(activation_timeout);
     }
 
     DeployData {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,7 @@ pub struct CmdOverrides {
     pub magic_rollback: Option<bool>,
     pub temp_path: Option<PathBuf>,
     pub confirm_timeout: Option<u16>,
+    pub activation_timeout: Option<u16>,
     pub sudo: Option<String>,
     pub dry_activate: bool,
     pub remote_build: bool,
@@ -443,6 +444,9 @@ pub fn make_deploy_data<'a, 's>(
     }
     if let Some(confirm_timeout) = cmd_overrides.confirm_timeout {
         merged_settings.confirm_timeout = Some(confirm_timeout);
+    }
+    if let Some(activation_timeout) = cmd_overrides.activation_timeout {
+        merged_settings.confirm_timeout = Some(activation_timeout);
     }
 
     DeployData {


### PR DESCRIPTION
Problem: Currently profile activation waiting timeout is hardcoded to 240 seconds, see https://github.com/serokell/deploy-rs/pull/48. In some cases, this timeout can be exceeded (e.g.
activation performs a heavy DB migration and waits for it to finish before considering the profile activation succesful).

Solution: Make this timeout configurable via 'activationTimeout' deploy attribute or corresponding '--activation-timeout' CLI option. For the sake of backward compatibility, the 'wait' subcommand new '--activation-timeout' option is made optional and defaults to 240 seconds if it wasn't provided.