### PR TITLE
[Chore] Add missing documentation for timeout options

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,18 @@ This is a set of options that can be put in any of the above definitions, with t
   # Will also fetch all external dependencies from the target system's substituters.
   # This default to `false`
   remoteBuild = true;
+
+  # Timeout for profile activation.
+  # This defaults to 240 seconds.
+  activationTimeout = 600;
+
+  # Timeout for profile activation confirmation.
+  # This defaults to 30 seconds.
+  confirmTimeout = 60;
 }
 ```
+
+Some of these options can be provided during `deploy` invocation to override default values or values provided in your flake, see `deploy --help`.
 
 ## About Serokell
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -85,7 +85,7 @@ pub struct Opts {
     /// How long activation should wait for confirmation (if using magic-rollback)
     #[clap(long)]
     confirm_timeout: Option<u16>,
-    /// How long we should wait for profile activation (if using magic-rollback)
+    /// How long we should wait for profile activation
     #[clap(long)]
     activation_timeout: Option<u16>,
     /// Where to store temporary files (only used by magic-rollback)


### PR DESCRIPTION
Problem: README misses documentation for 'confirmTimeout' and 'activationTimeout'.

Solution: Mention them in README.