### PR TITLE
Remove usage of alias

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -163,7 +163,7 @@
           inputsFrom = [ self.packages.${system}.deploy-rs ];
           RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
           buildInputs = with pkgs; [
-            nixUnstable
+            nixVersions.unstable
             cargo
             rustc
             rust-analyzer


### PR DESCRIPTION
Without this change I get the following error when I have aliases disabled in config.nix

```
error:
       … while calling the 'derivationStrict' builtin

         at /derivation-internal.nix:9:12:

            8|
            9|   strict = derivationStrict drvAttrs;
             |            ^
           10|

       … while evaluating derivation 'nix-shell'
         whose name attribute is located at /nix/store/vf6skxhiqknlnqcxh8n4z2jldzzpb171-source/pkgs/stdenv/generic/make-derivation.nix:348:7

       … while evaluating attribute 'buildInputs' of derivation 'nix-shell'

         at /nix/store/vf6skxhiqknlnqcxh8n4z2jldzzpb171-source/pkgs/stdenv/generic/make-derivation.nix:395:7:

          394|       depsHostHost                = elemAt (elemAt dependencies 1) 0;
          395|       buildInputs                 = elemAt (elemAt dependencies 1) 1;
             |       ^
          396|       depsTargetTarget            = elemAt (elemAt dependencies 2) 0;

       error: undefined variable 'nixUnstable'

       at /nix/store/d7axyqzr807l6ml099jzqbjhiy36mxcn-source/flake.nix:166:13:

          165|           buildInputs = with pkgs; [
          166|             nixUnstable
             |             ^
          167|             cargo
```