### PR TITLE
Add support for entering sudo password interactively

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,7 @@ dependencies = [
  "merge",
  "notify",
  "rnix",
+ "rpassword",
  "serde",
  "serde_json",
  "signal-hook",
@@ -667,6 +668,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,6 +881,7 @@ dependencies = [
  "autocfg",
  "bytes",
  "libc",
+ "memchr",
  "mio 0.7.6",
  "num_cpus",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0.104", features = [ "derive" ] }
 serde_json = "1.0.48"
 signal-hook = "0.3"
 thiserror = "1.0"
-tokio = { version = "1.9.0", features = [ "process", "macros", "sync", "rt-multi-thread", "fs", "time" ] }
+tokio = { version = "1.9.0", features = [ "process", "macros", "sync", "rt-multi-thread", "fs", "time", "io-util" ] }
 toml = "0.5"
 whoami = "0.9.0"
 yn = "0.1"
@@ -33,6 +33,7 @@ yn = "0.1"
 # 1.45.2 (shipped in nixos-20.09); it requires rustc 1.46.0. See
 # <https://github.com/serokell/deploy-rs/issues/27>:
 smol_str = "=0.1.16"
+rpassword = "7.3.1"
 
 
 [lib]

--- a/examples/system/flake.nix
+++ b/examples/system/flake.nix
@@ -26,6 +26,7 @@
       sshOpts = [ "-p" "2221" ];
       hostname = "localhost";
       fastConnection = true;
+      interactiveSudo = true;
       profiles = {
         system = {
           sshUser = "admin";

--- a/interface.json
+++ b/interface.json
@@ -35,6 +35,9 @@
                 },
                 "tempPath": {
                     "type": "string"
+                },
+                "interactiveSudo": {
+                    "type": "boolean"
                 }
             }
         },

--- a/src/data.rs
+++ b/src/data.rs
@@ -35,6 +35,8 @@ pub struct GenericSettings {
     pub sudo: Option<String>,
     #[serde(default,rename(deserialize = "remoteBuild"))]
     pub remote_build: Option<bool>,
+    #[serde(rename(deserialize = "interactiveSudo"))]
+    pub interactive_sudo: Option<bool>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,7 @@ pub struct CmdOverrides {
     pub confirm_timeout: Option<u16>,
     pub activation_timeout: Option<u16>,
     pub sudo: Option<String>,
+    pub interactive_sudo: Option<bool>,
     pub dry_activate: bool,
     pub remote_build: bool,
 }
@@ -334,6 +335,7 @@ pub struct DeployDefs {
     pub ssh_user: String,
     pub profile_user: String,
     pub sudo: Option<String>,
+    pub sudo_password: Option<String>,
 }
 enum ProfileInfo {
     ProfilePath {
@@ -369,6 +371,7 @@ impl<'a> DeployData<'a> {
             ssh_user,
             profile_user,
             sudo,
+            sudo_password: None,
         })
     }
 
@@ -447,6 +450,9 @@ pub fn make_deploy_data<'a, 's>(
     }
     if let Some(activation_timeout) = cmd_overrides.activation_timeout {
         merged_settings.activation_timeout = Some(activation_timeout);
+    }
+    if let Some(interactive_sudo) = cmd_overrides.interactive_sudo {
+        merged_settings.interactive_sudo = Some(interactive_sudo);
     }
 
     DeployData {


### PR DESCRIPTION
This adds a prompt for entering the sudo password interactively, so that system deployments can be activated when using non-root sshUsers. Fixes #78.

I have chosen to handle this locally (in deploy) and pipe the password to stdin of the ssh session, rather than via psuedo-terminal as this is more reliable. This also means that magicRollback works, unlike the "-t" workaround.