### PR TITLE
[Chore] Fix overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ In the above configuration, `deploy-rs` is built from the flake, not from nixpkg
     deployPkgs = import nixpkgs {
       inherit system;
       overlays = [
-        deploy-rs.overlay
+        deploy-rs.overlay # or deploy-rs.overlays.default
         (self: super: { deploy-rs = { inherit (pkgs) deploy-rs; lib = super.deploy-rs.lib; }; })
       ];
     };

--- a/flake.nix
+++ b/flake.nix
@@ -16,8 +16,8 @@
   };
 
   outputs = { self, nixpkgs, utils, ... }@inputs:
-  {
-    overlays.default = final: prev: let
+  rec {
+    overlay = final: prev: let
       system = final.stdenv.hostPlatform.system;
       darwinOptions = final.lib.optionalAttrs final.stdenv.isDarwin {
         buildInputs = with final.darwin.apple_sdk.frameworks; [
@@ -147,6 +147,7 @@
         };
       };
     };
+    overlays.default = overlay;
   } //
     utils.lib.eachSystem (utils.lib.defaultSystems ++ ["aarch64-darwin"]) (system:
       let


### PR DESCRIPTION
Problem: In my recent PR(#264), I accidentally picked overlay output changes from the [philtaken/nixos-vm-tests](https://github.com/serokell/deploy-rs/tree/philtaken/nixos-vm-tests), which broke existing overlay imports after updating the deploy-rs input.

Solution: Add backwards compatibility so that users don't have to make changes to their nix flakes.