### PR TITLE
add support for asynchronous building and pushing of profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -233,6 +233,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +260,7 @@ dependencies = [
  "flexi_logger",
  "fork",
  "futures-util",
+ "indicatif",
  "log",
  "merge",
  "notify",
@@ -257,6 +271,7 @@ dependencies = [
  "signal-hook",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-stream",
  "toml",
  "unescape",
  "whoami",
@@ -283,6 +298,12 @@ dependencies = [
  "redox_users",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -462,6 +483,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "futures-core",
+ "number_prefix",
+ "portable-atomic",
+ "tokio",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "inotify"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +589,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +687,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +714,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,6 +747,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "proc-macro-error"
@@ -855,6 +935,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,10 +1016,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
 name = "smol_str"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f7909a1d8bc166a862124d84fdc11bda0ea4ed3157ccca662296919c2972db1"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "strsim"
@@ -1035,8 +1137,10 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -1050,6 +1154,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1097,6 +1212,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8parse"
@@ -1201,6 +1322,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,6 +1387,12 @@ name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,14 @@ serde = { version = "1.0.219", features = [ "derive" ] }
 serde_json = "1.0.140"
 signal-hook = "0.3"
 thiserror = "2.0"
-tokio = { version = "1.44.0", features = [ "process", "macros", "sync", "rt-multi-thread", "fs", "time", "io-util" ] }
+tokio = { version = "1.44.0", features = [ "process", "macros", "sync", "rt-multi-thread", "fs", "time", "io-util", "rt", "full" ] }
 toml = "0.8"
 whoami = "1.6"
 yn = "0.1"
 rpassword = "7.3.1"
 unescape = "0.1.0"
+indicatif = { version = "0.17.8", features = ["tokio", "futures"] }
+tokio-stream = { version = "0.1.16", features = ["io-util"] }
 
 
 [lib]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@ use std::io::{stdin, stdout, Write};
 use std::time::Duration;
 
 use clap::{ArgMatches, FromArgMatches, Parser};
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle};
 use tokio::join;
 
 use crate as deploy;
@@ -373,7 +373,9 @@ fn prompt_deployment(
 
     if !yn::yes(&s) {
         if yn::is_somewhat_yes(&s) {
-            info!("Sounds like you might want to continue, to be more clear please just say \"yes\". Do you want to deploy these profiles?");
+            info!(
+                "Sounds like you might want to continue, to be more clear please just say \"yes\". Do you want to deploy these profiles?"
+            );
             print!("> ");
 
             stdout()
@@ -435,6 +437,10 @@ type ToDeploy<'a> = Vec<(
     (&'a str, &'a deploy::data::Profile),
 )>;
 
+fn separator(_state: &ProgressState, w: &mut dyn std::fmt::Write) {
+    let _ = write!(w, "│");
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_deploy(
     deploy_flakes: Vec<deploy::DeployFlake<'_>>,
@@ -492,7 +498,7 @@ async fn run_deploy(
                         let profile = match node.node_settings.profiles.get(profile_name) {
                             Some(x) => x,
                             None => {
-                                return Err(RunDeployError::ProfileNotFound(profile_name.clone()))
+                                return Err(RunDeployError::ProfileNotFound(profile_name.clone()));
                             }
                         };
 
@@ -523,7 +529,7 @@ async fn run_deploy(
                                 None => {
                                     return Err(RunDeployError::ProfileNotFound(
                                         profile_name.clone(),
-                                    ))
+                                    ));
                                 }
                             };
 
@@ -576,10 +582,14 @@ async fn run_deploy(
             .interactive_sudo
             .unwrap_or(false)
         {
-            warn!("Interactive sudo is enabled! Using a sudo password is less secure than correctly configured SSH keys.\nPlease use keys in production environments.");
+            warn!(
+                "Interactive sudo is enabled! Using a sudo password is less secure than correctly configured SSH keys.\nPlease use keys in production environments."
+            );
 
             if deploy_data.merged_settings.sudo.is_some() {
-                warn!("Custom sudo commands should be configured to accept password input from stdin when using the 'interactive sudo' option. Deployment may fail if the custom command ignores stdin.");
+                warn!(
+                    "Custom sudo commands should be configured to accept password input from stdin when using the 'interactive sudo' option. Deployment may fail if the custom command ignores stdin."
+                );
             } else {
                 // this configures sudo to hide the password prompt and accept input from stdin
                 // at the time of writing, deploy_defs.sudo defaults to 'sudo -u root' when using user=root and sshUser as non-root
@@ -650,13 +660,20 @@ async fn run_deploy(
 
     // show progress information
     let remote_mp = mp.clone();
-    let spinner_style = ProgressStyle::with_template("{spinner:.blue} {prefix} {msg}")
+    let spinner_style = ProgressStyle::with_template("{spinner:.blue} {prefix} {sep:.blue} {msg}")
         .expect("invalid template")
+        .with_key("sep", separator)
         .tick_strings(&["⢎ ", "⠎⠁", "⠊⠑", "⠈⠱", " ⡱", "⢀⡰", "⢄⡠", "⢆⡀"]);
-    let finish_style =
-        || ProgressStyle::with_template("✅ {prefix} {msg}").expect("invalid template");
-    let finish_style_error =
-        || ProgressStyle::with_template("❌ {prefix} {msg}").expect("invalid template");
+    let finish_style = || {
+        ProgressStyle::with_template("✅ {prefix} {sep:.blue} {msg}")
+            .expect("invalid template")
+            .with_key("sep", separator)
+    };
+    let finish_style_error = || {
+        ProgressStyle::with_template("❌ {prefix} {sep:.blue} {msg}")
+            .expect("invalid template")
+            .with_key("sep", separator)
+    };
     let new_spinner = || ProgressBar::new_spinner().with_style(spinner_style.clone());
 
     let (remote_results, local_results) = join!(
@@ -732,6 +749,8 @@ async fn run_deploy(
                     "Building profile '{}' for host '{}'",
                     profile_name, node_name
                 ));
+                pb.set_message("...");
+                data.deploy_data.progressbar = Some(pb.clone());
 
                 let res = deploy::push::build_profile(&data).await.map_err(|e| {
                     RunDeployError::BuildProfile(profile_name.clone(), node_name.clone(), e)
@@ -739,7 +758,6 @@ async fn run_deploy(
 
                 match res {
                     Ok(()) => {
-                        data.deploy_data.progressbar = Some(pb.clone());
                         set.spawn(async move {
                             let data = data.clone();
                             pb.set_prefix(format!(
@@ -905,7 +923,9 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
     let do_not_want_flakes = opts.file.is_some();
 
     if !supports_flakes {
-        warn!("A Nix version without flakes support was detected, support for this is work in progress");
+        warn!(
+            "A Nix version without flakes support was detected, support for this is work in progress"
+        );
     }
 
     if do_not_want_flakes {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,8 +5,11 @@
 
 use std::collections::HashMap;
 use std::io::{stdin, stdout, Write};
+use std::time::Duration;
 
 use clap::{ArgMatches, FromArgMatches, Parser};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use tokio::join;
 
 use crate as deploy;
 use crate::command;
@@ -19,6 +22,7 @@ use std::path::PathBuf;
 use std::process::Stdio;
 use thiserror::Error;
 use tokio::process::Command;
+use tokio::task::JoinSet;
 
 /// Simple Rust rewrite of a simple Nix Flake deployment tool
 #[derive(Parser, Debug, Clone)]
@@ -400,12 +404,12 @@ fn prompt_deployment(
 
 #[derive(Error, Debug)]
 pub enum RunDeployError {
-    #[error("Failed to deploy profile to node {0}: {1}")]
-    DeployProfile(String, deploy::deploy::DeployProfileError),
-    #[error("Failed to build profile on node {0}: {1}")]
-    BuildProfile(String, deploy::push::PushProfileError),
-    #[error("Failed to push profile to node {0}: {1}")]
-    PushProfile(String, deploy::push::PushProfileError),
+    #[error("Failed to deploy profile {0} to node {1}: {2}")]
+    DeployProfile(String, String, deploy::deploy::DeployProfileError),
+    #[error("Failed to build profile {0} on node {1}: {2}")]
+    BuildProfile(String, String, deploy::push::PushProfileError),
+    #[error("Failed to push profile {0} to node {1}: {2}")]
+    PushProfile(String, String, deploy::push::PushProfileError),
     #[error("No profile named `{0}` was found")]
     ProfileNotFound(String),
     #[error("No node named `{0}` was found")]
@@ -418,15 +422,15 @@ pub enum RunDeployError {
     TomlFormat(#[from] toml::ser::Error),
     #[error("{0}")]
     PromptDeployment(#[from] PromptDeploymentError),
-    #[error("Failed to revoke profile for node {0}: {1}")]
-    RevokeProfile(String, deploy::deploy::RevokeProfileError),
+    #[error("Failed to revoke profile {0} for node {1}: {2}")]
+    RevokeProfile(String, String, deploy::deploy::RevokeProfileError),
     #[error("Deployment to node {0} failed, rolled back to previous generation")]
     Rollback(String),
 }
 
 type ToDeploy<'a> = Vec<(
     &'a deploy::DeployFlake<'a>,
-    &'a deploy::data::Data,
+    deploy::data::Data,
     (&'a str, &'a deploy::data::Node),
     (&'a str, &'a deploy::data::Profile),
 )>;
@@ -447,6 +451,7 @@ async fn run_deploy(
     boot: bool,
     log_dir: &Option<String>,
     rollback_succeeded: bool,
+    mp: MultiProgress,
 ) -> Result<(), RunDeployError> {
     let to_deploy: ToDeploy = deploy_flakes
         .iter()
@@ -465,7 +470,7 @@ async fn run_deploy(
 
                     vec![(
                         deploy_flake,
-                        data,
+                        data.clone(),
                         (node_name.as_str(), node),
                         (profile_name.as_str(), profile),
                     )]
@@ -498,7 +503,7 @@ async fn run_deploy(
 
                     profiles_list
                         .into_iter()
-                        .map(|x| (deploy_flake, data, (node_name.as_str(), node), x))
+                        .map(|x| (deploy_flake, data.clone(), (node_name.as_str(), node), x))
                         .collect()
                 }
                 (None, None) => {
@@ -529,7 +534,7 @@ async fn run_deploy(
 
                         let ll: ToDeploy = profiles_list
                             .into_iter()
-                            .map(|x| (deploy_flake, data, (node_name.as_str(), node), x))
+                            .map(|x| (deploy_flake, data.clone(), (node_name.as_str(), node), x))
                             .collect();
 
                         l.extend(ll);
@@ -556,12 +561,12 @@ async fn run_deploy(
         let deploy_data = deploy::make_deploy_data(
             &data.generic_settings,
             node,
-            node_name,
+            node_name.to_string(),
             profile,
-            profile_name,
+            profile_name.to_string(),
             cmd_overrides,
             debug_logs,
-            log_dir.as_deref(),
+            log_dir.clone(),
         );
 
         let mut deploy_defs = deploy_data.defs()?;
@@ -609,36 +614,181 @@ async fn run_deploy(
             |(deploy_flake, deploy_data, deploy_defs)| deploy::push::PushProfileData {
                 supports_flakes,
                 check_sigs,
-                repo: deploy_flake.repo,
-                deploy_data,
-                deploy_defs,
+                repo: deploy_flake.repo.to_string(),
+                deploy_data: deploy_data.clone(),
+                deploy_defs: deploy_defs.clone(),
                 keep_result,
-                result_path,
-                extra_build_args,
+                result_path: result_path.map(str::to_string),
+                extra_build_args: extra_build_args.to_vec(),
             },
         )
     };
 
-    for data in data_iter() {
-        let node_name: String = data.deploy_data.node_name.to_string();
-        deploy::push::build_profile(data)
-            .await
-            .map_err(|e| RunDeployError::BuildProfile(node_name, e))?;
+    let (remote_builds, local_builds): (Vec<_>, Vec<_>) = data_iter().partition(|data| {
+        data.deploy_data
+            .merged_settings
+            .remote_build
+            .unwrap_or_default()
+    });
+
+    // the grouping by host will retain each hosts ordering by profiles_order since the fold is synchronous
+    let remote_build_map: HashMap<_, Vec<_>> =
+        remote_builds
+            .into_iter()
+            .fold(HashMap::new(), |mut accum, elem| {
+                match accum.get_mut(&elem.deploy_data.node_name) {
+                    Some(v) => {
+                        v.push(elem);
+                        accum
+                    }
+                    None => {
+                        accum.insert(elem.deploy_data.node_name.clone(), vec![elem]);
+                        accum
+                    }
+                }
+            });
+
+    // show progress information
+    let remote_mp = mp.clone();
+    let spinner_style = ProgressStyle::with_template("{spinner:.blue} {prefix} {msg}")
+        .expect("invalid template")
+        .tick_strings(&["⢎ ", "⠎⠁", "⠊⠑", "⠈⠱", " ⡱", "⢀⡰", "⢄⡠", "⢆⡀"]);
+    let finish_style =
+        || ProgressStyle::with_template("✅ {prefix} {msg}").expect("invalid template");
+    let finish_style_error =
+        || ProgressStyle::with_template("❌ {prefix} {msg}").expect("invalid template");
+    let new_spinner = || ProgressBar::new_spinner().with_style(spinner_style.clone());
+
+    let (remote_results, local_results) = join!(
+        // remote builds can be run asynchronously
+        async move {
+            let mut set = JoinSet::new();
+
+            #[allow(clippy::iter_kv_map)]
+            for (_, profiles) in remote_build_map {
+                // spawn one future for each host
+                let pb = remote_mp.add(new_spinner());
+                pb.enable_steady_tick(Duration::from_millis(80));
+
+                set.spawn(async move {
+                    let mut res = Ok(());
+
+                    // build profile in order, one after the other
+                    for mut profile in profiles {
+                        let nodename = profile.deploy_data.node_name.clone();
+                        let profilename = profile.deploy_data.profile_name.clone();
+                        pb.set_prefix(format!(
+                            "Building profile '{}' on host '{}'",
+                            profilename, nodename
+                        ));
+                        pb.set_message("...");
+                        profile.deploy_data.progressbar = Some(pb.clone());
+
+                        info!(
+                            "starting build of profile {} on node {}",
+                            profilename, nodename
+                        );
+
+                        res = deploy::push::build_profile(&profile).await.map_err(|e| {
+                            RunDeployError::BuildProfile(
+                                profilename.to_string(),
+                                nodename.to_string(),
+                                e,
+                            )
+                        });
+                        if res.is_err() {
+                            break;
+                        }
+                    }
+
+                    match res {
+                        Ok(()) => {
+                            pb.set_style(finish_style());
+                            pb.finish_with_message("Done!");
+                        }
+                        Err(ref e) => {
+                            pb.set_style(finish_style_error());
+                            pb.finish_with_message(format!("Error: {}", e))
+                        }
+                    }
+
+                    res
+                });
+            }
+
+            set.join_all().await
+        },
+        // run local builds synchronously to prevent hardware deadlocks
+        async move {
+            let mut set = JoinSet::new();
+
+            for mut data in local_builds.into_iter() {
+                let pb = mp.add(new_spinner());
+                pb.enable_steady_tick(Duration::from_millis(80));
+
+                let node_name = data.deploy_data.node_name.to_string();
+                let profile_name = data.deploy_data.profile_name.to_string();
+                pb.set_prefix(format!(
+                    "Building profile '{}' for host '{}'",
+                    profile_name, node_name
+                ));
+
+                let res = deploy::push::build_profile(&data).await.map_err(|e| {
+                    RunDeployError::BuildProfile(profile_name.clone(), node_name.clone(), e)
+                });
+
+                match res {
+                    Ok(()) => {
+                        data.deploy_data.progressbar = Some(pb.clone());
+                        set.spawn(async move {
+                            let data = data.clone();
+                            pb.set_prefix(format!(
+                                "Pushing profile '{}' to host '{}'",
+                                profile_name, node_name
+                            ));
+                            let res = deploy::push::push_profile(&data).await.map_err(|e| {
+                                RunDeployError::PushProfile(profile_name, node_name, e)
+                            });
+                            match res {
+                                Ok(()) => {
+                                    pb.set_style(finish_style());
+                                    pb.finish_with_message("Done!");
+                                }
+                                Err(ref e) => {
+                                    pb.set_style(finish_style_error());
+                                    pb.finish_with_message(format!("Error: {}", e))
+                                }
+                            }
+                            res
+                        });
+                    }
+                    Err(ref e) => {
+                        pb.set_style(finish_style_error());
+                        pb.finish_with_message(format!("Error: {}", e));
+                        // "spawn" a future that just returns the error when building locally fails
+                        // this will ensure that the deployment is actually aborted in the error
+                        // handling code below
+                        set.spawn(async move { res });
+                    }
+                }
+            }
+            set.join_all().await
+        }
+    );
+
+    // abort here if any build + push or push + build failed
+    for result in remote_results {
+        result?
+    }
+    for result in local_results {
+        result?
     }
 
-    for data in data_iter() {
-        let node_name: String = data.deploy_data.node_name.to_string();
-        deploy::push::push_profile(data)
-            .await
-            .map_err(|e| RunDeployError::PushProfile(node_name, e))?;
-    }
-
-    let mut succeeded: Vec<(&deploy::DeployData, &deploy::DeployDefs)> = vec![];
-
-    // Run all deployments
-    // In case of an error rollback any previoulsy made deployment.
+    // Run all activations
+    // In case of an error, rollback any previoulsy made deployment.
     // Rollbacks adhere to the global seeting to auto_rollback and secondary
     // the profile's configuration
+    let mut succeeded: Vec<(&deploy::DeployData, &deploy::DeployDefs)> = vec![];
     for (_, deploy_data, deploy_defs) in &parts {
         if let Err(e) =
             deploy::deploy::deploy_profile(deploy_data, deploy_defs, dry_activate, boot).await
@@ -657,13 +807,18 @@ async fn run_deploy(
                         deploy::deploy::revoke(deploy_data, deploy_defs)
                             .await
                             .map_err(|e| {
-                                RunDeployError::RevokeProfile(deploy_data.node_name.to_string(), e)
+                                RunDeployError::RevokeProfile(
+                                    deploy_data.profile_name.to_string(),
+                                    deploy_data.node_name.to_string(),
+                                    e,
+                                )
                             })?;
                     }
                 }
                 return Err(RunDeployError::Rollback(deploy_data.node_name.to_string()));
             }
             return Err(RunDeployError::DeployProfile(
+                deploy_data.profile_name.to_string(),
                 deploy_data.node_name.to_string(),
                 e,
             ));
@@ -702,7 +857,7 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
         None => Opts::parse(),
     };
 
-    deploy::init_logger(
+    let (mp, _handle) = deploy::init_logger(
         opts.debug_logs,
         opts.log_dir.as_deref(),
         &deploy::LoggerType::Deploy,
@@ -781,6 +936,7 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
         opts.boot,
         &opts.log_dir,
         opts.rollback_succeeded.unwrap_or(true),
+        mp,
     )
     .await?;
 

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -284,7 +284,7 @@ pub enum ConfirmProfileError {
 }
 
 pub async fn confirm_profile(
-    deploy_data: &super::DeployData<'_>,
+    deploy_data: &super::DeployData,
     deploy_defs: &super::DeployDefs,
     temp_path: &Path,
     ssh_addr: &str,
@@ -313,7 +313,7 @@ pub async fn confirm_profile(
     let mut ssh_confirm_child = ssh_confirm_command
         .arg(confirm_command)
         .spawn()
-        .map_err(|err| ConfirmProfileError::SSHConfirm(command::CommandError::RunError(err)))?;
+        .map_err(|e| ConfirmProfileError::SSHConfirm(command::CommandError::RunError(e)))?;
 
     if deploy_data
         .merged_settings
@@ -388,7 +388,7 @@ pub enum DeployProfileError {
 }
 
 pub async fn deploy_profile(
-    deploy_data: &super::DeployData<'_>,
+    deploy_data: &super::DeployData,
     deploy_defs: &super::DeployDefs,
     dry_activate: bool,
     boot: bool,
@@ -422,7 +422,7 @@ pub async fn deploy_profile(
         confirm_timeout,
         magic_rollback,
         debug_logs: deploy_data.debug_logs,
-        log_dir: deploy_data.log_dir,
+        log_dir: deploy_data.log_dir.as_deref(),
         dry_activate,
         boot,
     });
@@ -501,7 +501,7 @@ pub async fn deploy_profile(
             temp_path,
             activation_timeout,
             debug_logs: deploy_data.debug_logs,
-            log_dir: deploy_data.log_dir,
+            log_dir: deploy_data.log_dir.as_deref(),
         });
 
         debug!("Constructed wait command: {}", self_wait_command);
@@ -653,7 +653,7 @@ pub enum RevokeProfileError {
     InvalidDeployDataDefs(#[from] DeployDataDefsError),
 }
 pub async fn revoke(
-    deploy_data: &crate::DeployData<'_>,
+    deploy_data: &crate::DeployData,
     deploy_defs: &crate::DeployDefs,
 ) -> Result<(), RevokeProfileError> {
     let self_revoke_command = build_revoke_command(&RevokeCommandData {
@@ -661,7 +661,7 @@ pub async fn revoke(
         closure: &deploy_data.profile.profile_settings.path,
         profile_info: deploy_data.get_profile_info()?,
         debug_logs: deploy_data.debug_logs,
-        log_dir: deploy_data.log_dir,
+        log_dir: deploy_data.log_dir.as_deref(),
     });
 
     debug!("Constructed revoke command: {}", self_revoke_command);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+use indicatif::MultiProgress;
 use rnix::{types::*, SyntaxKind::*};
 
 use merge::Merge;
@@ -100,11 +101,63 @@ pub enum LoggerType {
     Revoke,
 }
 
+use log::Log;
+
+pub struct LogWrapper {
+    bar: MultiProgress,
+    log: Box<dyn Log>,
+}
+
+impl LogWrapper {
+    pub fn new(bar: MultiProgress, log: Box<dyn Log>) -> Self {
+        Self { bar, log }
+    }
+
+    pub fn try_init(self) -> Result<(), log::SetLoggerError> {
+        use log::LevelFilter::*;
+        let levels = [Off, Error, Warn, Info, Debug, Trace];
+
+        for level_filter in levels.iter().rev() {
+            let level = if let Some(level) = level_filter.to_level() {
+                level
+            } else {
+                continue;
+            };
+            let meta = log::Metadata::builder().level(level).build();
+            if self.enabled(&meta) {
+                log::set_max_level(*level_filter);
+                break;
+            }
+        }
+
+        log::set_boxed_logger(Box::new(self))
+    }
+    pub fn multi(&self) -> MultiProgress {
+        self.bar.clone()
+    }
+}
+
+impl Log for LogWrapper {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        self.log.enabled(metadata)
+    }
+
+    fn log(&self, record: &log::Record) {
+        if self.log.enabled(record.metadata()) {
+            self.bar.suspend(|| self.log.log(record))
+        }
+    }
+
+    fn flush(&self) {
+        self.log.flush()
+    }
+}
+
 pub fn init_logger(
     debug_logs: bool,
     log_dir: Option<&str>,
     logger_type: &LoggerType,
-) -> Result<(), FlexiLoggerError> {
+) -> Result<(MultiProgress, ReconfigurationHandle), FlexiLoggerError> {
     let logger_formatter = match &logger_type {
         LoggerType::Deploy => logger_formatter_deploy,
         LoggerType::Activate => logger_formatter_activate,
@@ -112,7 +165,7 @@ pub fn init_logger(
         LoggerType::Revoke => logger_formatter_revoke,
     };
 
-    if let Some(log_dir) = log_dir {
+    let (logger, handle) = if let Some(log_dir) = log_dir {
         let mut logger = Logger::with_env_or_str("debug")
             .log_to_file()
             .format_for_stderr(logger_formatter)
@@ -131,7 +184,7 @@ pub fn init_logger(
             LoggerType::Deploy => (),
         }
 
-        logger.start()?;
+        logger.build()?
     } else {
         Logger::with_env_or_str(match debug_logs {
             true => "debug",
@@ -140,10 +193,13 @@ pub fn init_logger(
         .log_target(LogTarget::StdErr)
         .format(logger_formatter)
         .set_palette("196;208;51;7;8".to_string())
-        .start()?;
-    }
+        .build()?
+    };
 
-    Ok(())
+    let multi = MultiProgress::new();
+    LogWrapper::new(multi.clone(), logger).try_init().unwrap();
+
+    Ok((multi, handle))
 }
 
 pub mod cli;
@@ -152,7 +208,7 @@ pub mod data;
 pub mod deploy;
 pub mod push;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CmdOverrides {
     pub ssh_user: Option<String>,
     pub profile_user: Option<String>,
@@ -350,21 +406,23 @@ pub fn parse_file<'a>(
 }
 
 #[derive(Debug, Clone)]
-pub struct DeployData<'a> {
-    pub node_name: &'a str,
-    pub node: &'a data::Node,
-    pub profile_name: &'a str,
-    pub profile: &'a data::Profile,
+pub struct DeployData {
+    pub node_name: String,
+    pub node: data::Node,
+    pub profile_name: String,
+    pub profile: data::Profile,
 
-    pub cmd_overrides: &'a CmdOverrides,
+    pub cmd_overrides: CmdOverrides,
 
     pub merged_settings: data::GenericSettings,
 
     pub debug_logs: bool,
-    pub log_dir: Option<&'a str>,
+    pub log_dir: Option<String>,
+
+    pub progressbar: Option<indicatif::ProgressBar>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DeployDefs {
     pub ssh_user: String,
     pub profile_user: String,
@@ -387,8 +445,8 @@ pub enum DeployDataDefsError {
     NoProfileUser(String, String),
 }
 
-impl<'a> DeployData<'a> {
-    pub fn defs(&'a self) -> Result<DeployDefs, DeployDataDefsError> {
+impl DeployData {
+    pub fn defs(&self) -> Result<DeployDefs, DeployDataDefsError> {
         let ssh_user = match self.merged_settings.ssh_user {
             Some(ref u) => u.clone(),
             None => whoami::username(),
@@ -409,7 +467,7 @@ impl<'a> DeployData<'a> {
         })
     }
 
-    fn get_profile_user(&'a self) -> Result<String, DeployDataDefsError> {
+    fn get_profile_user(&self) -> Result<String, DeployDataDefsError> {
         let profile_user = match self.merged_settings.user {
             Some(ref x) => x.clone(),
             None => match self.merged_settings.ssh_user {
@@ -425,14 +483,14 @@ impl<'a> DeployData<'a> {
         Ok(profile_user)
     }
 
-    fn get_sudo(&'a self) -> String {
+    fn get_sudo(&self) -> String {
         match self.merged_settings.sudo {
             Some(ref x) => x.clone(),
             None => "sudo -u".to_string(),
         }
     }
 
-    fn get_profile_info(&'a self) -> Result<ProfileInfo, DeployDataDefsError> {
+    fn get_profile_info(&self) -> Result<ProfileInfo, DeployDataDefsError> {
         match self.profile.profile_settings.profile_path {
             Some(ref profile_path) => Ok(ProfileInfo::ProfilePath {
                 profile_path: profile_path.to_string(),
@@ -449,16 +507,16 @@ impl<'a> DeployData<'a> {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn make_deploy_data<'a>(
+pub fn make_deploy_data(
     top_settings: &data::GenericSettings,
-    node: &'a data::Node,
-    node_name: &'a str,
-    profile: &'a data::Profile,
-    profile_name: &'a str,
-    cmd_overrides: &'a CmdOverrides,
+    node: &data::Node,
+    node_name: String,
+    profile: &data::Profile,
+    profile_name: String,
+    cmd_overrides: &CmdOverrides,
     debug_logs: bool,
-    log_dir: Option<&'a str>,
-) -> DeployData<'a> {
+    log_dir: Option<String>,
+) -> DeployData {
     let mut merged_settings = profile.generic_settings.clone();
     merged_settings.merge(node.generic_settings.clone());
     merged_settings.merge(top_settings.clone());
@@ -497,12 +555,13 @@ pub fn make_deploy_data<'a>(
 
     DeployData {
         node_name,
-        node,
+        node: node.clone(),
         profile_name,
-        profile,
-        cmd_overrides,
+        profile: profile.clone(),
+        cmd_overrides: cmd_overrides.clone(),
         merged_settings,
         debug_logs,
         log_dir,
+        progressbar: None,
     }
 }

--- a/src/push.rs
+++ b/src/push.rs
@@ -4,6 +4,7 @@
 
 use indicatif::ProgressBar;
 use log::{debug, info, warn};
+use std::collections::HashMap;
 use std::path::Path;
 use std::process::Stdio;
 use thiserror::Error;
@@ -91,8 +92,10 @@ pub enum PushProfileError {
              Did you forget to use deploy-rs#lib.<...>.activate.<...> on your profile path?"
     )]
     DeployRsActivateDoesntExist,
-    #[error("Activation script activate-rs does not exist in profile.\n\
-             Is there a mismatch in deploy-rs used in the flake you're deploying and deploy-rs command you're running?")]
+    #[error(
+        "Activation script activate-rs does not exist in profile.\n\
+             Is there a mismatch in deploy-rs used in the flake you're deploying and deploy-rs command you're running?"
+    )]
     ActivateRsDoesntExist,
 }
 
@@ -151,10 +154,32 @@ pub async fn build_profile_locally(
         // Logging should be in stderr, this just stops the store path from printing for no reason
         .stdout(Stdio::null());
 
-    let build_status = command::Command::new(build_command)
-        .status()
-        .await
-        .map_err(PushProfileError::Build)?;
+    debug!("build command: {:?}", build_command);
+
+    // When a progress bar is attached, pipe nix's stderr and route each line
+    // through the spinner's message. Otherwise nix detects the terminal and
+    // draws its own `[x/y built]` bar directly, which corrupts the display.
+    let build_status = if let Some(pb) = &data.deploy_data.progressbar {
+        // `internal-json` gives us structured progress to render in the spinner
+        // instead of nix's own (terminal-drawing) progress bar.
+        build_command.arg("--log-format").arg("internal-json");
+        let mut child = build_command
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?;
+
+        update_pb_with_child_output(pb, &mut child).await;
+
+        child
+            .wait()
+            .await
+            .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?
+    } else {
+        command::Command::new(build_command)
+            .status()
+            .await
+            .map_err(PushProfileError::Build)?
+    };
 
     match build_status.code() {
         Some(0) => (),
@@ -206,22 +231,193 @@ pub async fn build_profile_locally(
     Ok(())
 }
 
+// Nix `internal-json` activity types (see nix's `logging.hh`).
+const ACT_COPY_PATHS: i64 = 103;
+const ACT_BUILDS: i64 = 104;
+const ACT_FILE_TRANSFER: i64 = 101;
+// Result types.
+const RES_PROGRESS: i64 = 105;
+const RES_BUILD_LOG_LINE: i64 = 101;
+
+/// Accumulates the aggregate progress reported by `nix --log-format internal-json`
+/// so we can render a compact `x/y built, x/y copied` message next to the spinner,
+/// mirroring nix's own progress bar.
+#[derive(Default)]
+struct NixProgress {
+    // Map of activity id -> activity type, so `result` events can be attributed.
+    activities: HashMap<u64, i64>,
+    builds: (u64, u64),
+    copies: (u64, u64),
+    // Downloads are not an aggregate activity: each file transfer reports its
+    // own byte count, so we track the latest bytes per active transfer and keep
+    // a running total of finished ones to render a single `X MiB DL` figure.
+    download_active: HashMap<u64, u64>,
+    download_done: u64,
+    // The most recent human-readable activity text (current path, build log line, ...).
+    last_line: String,
+}
+
+/// Render a byte count the way nix's own progress bar does (KiB/MiB/GiB, base 1024).
+fn human_bytes(n: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut value = n as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{} {}", n, UNITS[unit])
+    } else {
+        format!("{:.1} {}", value, UNITS[unit])
+    }
+}
+
+impl NixProgress {
+    /// Ingest one line of child output. Returns `true` if it was a structured
+    /// `@nix` message (already handled), `false` if it is a plain log line the
+    /// caller should surface directly.
+    fn ingest(&mut self, line: &str) -> bool {
+        let json = match line.strip_prefix("@nix ") {
+            Some(json) => json,
+            None => return false,
+        };
+        let value: serde_json::Value = match serde_json::from_str(json) {
+            Ok(value) => value,
+            Err(_) => return false,
+        };
+
+        let action = value.get("action").and_then(|a| a.as_str()).unwrap_or("");
+        match action {
+            "start" => {
+                let id = value.get("id").and_then(serde_json::Value::as_u64);
+                let typ = value.get("type").and_then(serde_json::Value::as_i64);
+                if let (Some(id), Some(typ)) = (id, typ) {
+                    self.activities.insert(id, typ);
+                }
+                // Show the individual operation (copying/downloading/building '...').
+                if let Some(text) = value.get("text").and_then(serde_json::Value::as_str) {
+                    if !text.is_empty() {
+                        self.last_line = text.to_string();
+                    }
+                }
+            }
+            "stop" => {
+                if let Some(id) = value.get("id").and_then(serde_json::Value::as_u64) {
+                    // Fold a finished download's bytes into the running total.
+                    if let Some(bytes) = self.download_active.remove(&id) {
+                        self.download_done += bytes;
+                    }
+                    self.activities.remove(&id);
+                }
+            }
+            "result" => {
+                let id = value.get("id").and_then(serde_json::Value::as_u64);
+                let rtype = value.get("type").and_then(serde_json::Value::as_i64);
+                let fields = value.get("fields").and_then(serde_json::Value::as_array);
+                match rtype {
+                    // Progress on an aggregate activity: fields = [done, expected, running, failed].
+                    Some(RES_PROGRESS) => {
+                        if let (Some(&atype), Some(fields)) =
+                            (id.and_then(|id| self.activities.get(&id)), fields)
+                        {
+                            let done = fields.first().and_then(serde_json::Value::as_u64);
+                            let expected = fields.get(1).and_then(serde_json::Value::as_u64);
+                            match atype {
+                                ACT_BUILDS => {
+                                    if let (Some(done), Some(expected)) = (done, expected) {
+                                        self.builds = (done, expected);
+                                    }
+                                }
+                                ACT_COPY_PATHS => {
+                                    if let (Some(done), Some(expected)) = (done, expected) {
+                                        self.copies = (done, expected);
+                                    }
+                                }
+                                // fields[0] is this transfer's downloaded bytes.
+                                ACT_FILE_TRANSFER => {
+                                    if let (Some(id), Some(done)) = (id, done) {
+                                        self.download_active.insert(id, done);
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                    // A line of build output from a running derivation.
+                    Some(RES_BUILD_LOG_LINE) => {
+                        if let Some(text) = fields
+                            .and_then(|f| f.first())
+                            .and_then(serde_json::Value::as_str)
+                        {
+                            if !text.is_empty() {
+                                self.last_line = text.to_string();
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+        true
+    }
+
+    /// Render the accumulated state into a spinner message.
+    fn message(&self) -> String {
+        let mut counts = Vec::new();
+        if self.builds.1 > 0 {
+            counts.push(format!("{}/{} built", self.builds.0, self.builds.1));
+        }
+        if self.copies.1 > 0 {
+            counts.push(format!("{}/{} copied", self.copies.0, self.copies.1));
+        }
+        let downloaded: u64 = self.download_done + self.download_active.values().sum::<u64>();
+        if downloaded > 0 {
+            counts.push(format!("{} DL", human_bytes(downloaded)));
+        }
+        let counts = counts.join(", ");
+
+        match (counts.is_empty(), self.last_line.is_empty()) {
+            (false, false) => format!("[{}] {}", counts, self.last_line),
+            (false, true) => counts,
+            (true, false) => self.last_line.clone(),
+            (true, true) => "...".to_string(),
+        }
+    }
+}
+
 async fn update_pb_with_child_output(pb: &ProgressBar, child: &mut Child) {
+    // Only follow the streams that were actually piped. Some callers null out
+    // stdout (e.g. local builds, where nix prints the store path there), so we
+    // must not assume both handles are present.
     let stdout = child
         .stdout
         .take()
-        .expect("child did not have a stdout handle");
+        .map(|out| LinesStream::new(BufReader::new(out).lines()));
     let stderr = child
         .stderr
         .take()
-        .expect("child did not have a stderr handle");
+        .map(|err| LinesStream::new(BufReader::new(err).lines()));
 
-    let stdout = LinesStream::new(BufReader::new(stdout).lines());
-    let stderr = LinesStream::new(BufReader::new(stderr).lines());
-    let mut merged = StreamExt::merge(stdout, stderr);
+    let mut merged = match (stdout, stderr) {
+        (Some(out), Some(err)) => Box::pin(StreamExt::merge(out, err))
+            as std::pin::Pin<Box<dyn tokio_stream::Stream<Item = _> + Send>>,
+        (Some(out), None) => Box::pin(out),
+        (None, Some(err)) => Box::pin(err),
+        (None, None) => return,
+    };
 
+    let mut progress = NixProgress::default();
     while let Some(line) = merged.next().await {
-        pb.set_message(line.expect("expected a valid line"));
+        let line = line.expect("expected a valid line");
+        // Structured `@nix` events feed the aggregate counters; anything else
+        // (e.g. a stray warning) is shown verbatim.
+        if progress.ingest(&line) {
+            pb.set_message(progress.message());
+        } else if !line.is_empty() {
+            pb.set_message(line);
+        }
     }
 }
 
@@ -254,6 +450,10 @@ pub async fn build_profile_remotely(
             .arg("--derivation")
             .arg(derivation_name)
             .env("NIX_SSHOPTS", ssh_opts_str.clone());
+
+        if data.deploy_data.progressbar.is_some() {
+            copy_command.arg("--log-format").arg("internal-json");
+        }
 
         debug!("copy command: {:?}", copy_command);
 
@@ -289,6 +489,10 @@ pub async fn build_profile_remotely(
             .arg(&store_address)
             .args(data.extra_build_args.clone())
             .env("NIX_SSHOPTS", ssh_opts_str.clone());
+
+        if data.deploy_data.progressbar.is_some() {
+            build_command.arg("--log-format").arg("internal-json");
+        }
 
         debug!("build command: {:?}", build_command);
 
@@ -341,7 +545,7 @@ pub async fn build_profile(data: &PushProfileData) -> Result<(), PushProfileErro
         _exit_code => {
             return Err(PushProfileError::ShowDerivation(
                 command::CommandError::Exit(show_derivation_output, show_derivation_command_str),
-            ))
+            ));
         }
     };
 
@@ -487,10 +691,35 @@ pub async fn push_profile(data: &PushProfileData) -> Result<(), PushProfileError
             .arg(format!("ssh://{}@{}", data.deploy_defs.ssh_user, hostname))
             .arg(&data.deploy_data.profile.profile_settings.path)
             .env("NIX_SSHOPTS", ssh_opts_str);
-        command::Command::new(copy_command)
-            .status()
+
+        if data.deploy_data.progressbar.is_some() {
+            copy_command.arg("--log-format").arg("internal-json");
+        }
+
+        debug!("copy command: {:?}", copy_command);
+
+        // Pipe the output so nix does not draw directly to the terminal (which
+        // corrupts the progress bars); instead route each line through the
+        // spinner's message via `update_pb_with_child_output`.
+        let mut child = copy_command
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to spawn nix copy command");
+
+        if let Some(pb) = &data.deploy_data.progressbar {
+            update_pb_with_child_output(pb, &mut child).await;
+        }
+
+        let copy_exit_status = child
+            .wait()
             .await
-            .map_err(PushProfileError::Copy)?;
+            .map_err(|e| PushProfileError::Copy(command::CommandError::RunError(e)))?;
+
+        match copy_exit_status.code() {
+            Some(0) => (),
+            a => return Err(PushProfileError::CopyExit(a)),
+        };
     }
 
     Ok(())

--- a/src/push.rs
+++ b/src/push.rs
@@ -2,11 +2,17 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+use indicatif::ProgressBar;
 use log::{debug, info, warn};
 use std::path::Path;
 use std::process::Stdio;
 use thiserror::Error;
+use tokio::io::AsyncBufReadExt;
+use tokio::io::BufReader;
+use tokio::process::Child;
 use tokio::process::Command;
+use tokio_stream::wrappers::LinesStream;
+use tokio_stream::StreamExt;
 
 use crate::command;
 
@@ -76,6 +82,10 @@ pub enum PushProfileError {
     Copy(#[from] command::CommandError<CopyError>),
     #[error("{0}")]
     PathInfo(#[from] command::CommandError<PathInfoError>),
+    #[error("Copy exited with status {}", .0.map(|c| c.to_string()).unwrap_or_else(|| "unknown".to_string()))]
+    CopyExit(Option<i32>),
+    #[error("Build exited with status {}", .0.map(|c| c.to_string()).unwrap_or_else(|| "unknown".to_string()))]
+    BuildExit(Option<i32>),
     #[error(
         "Activation script deploy-rs-activate does not exist in profile.\n\
              Did you forget to use deploy-rs#lib.<...>.activate.<...> on your profile path?"
@@ -86,19 +96,20 @@ pub enum PushProfileError {
     ActivateRsDoesntExist,
 }
 
-pub struct PushProfileData<'a> {
+#[derive(Clone)]
+pub struct PushProfileData {
     pub supports_flakes: bool,
     pub check_sigs: bool,
-    pub repo: &'a str,
-    pub deploy_data: &'a super::DeployData<'a>,
-    pub deploy_defs: &'a super::DeployDefs,
+    pub repo: String,
+    pub deploy_data: super::DeployData,
+    pub deploy_defs: super::DeployDefs,
     pub keep_result: bool,
-    pub result_path: Option<&'a str>,
-    pub extra_build_args: &'a [String],
+    pub result_path: Option<String>,
+    pub extra_build_args: Vec<String>,
 }
 
 pub async fn build_profile_locally(
-    data: &PushProfileData<'_>,
+    data: &PushProfileData,
     derivation_name: &str,
 ) -> Result<(), PushProfileError> {
     info!(
@@ -120,7 +131,10 @@ pub async fn build_profile_locally(
 
     match (data.keep_result, data.supports_flakes) {
         (true, _) => {
-            let result_path = data.result_path.unwrap_or("./.deploy-gc");
+            let result_path = data
+                .result_path
+                .clone()
+                .unwrap_or("./.deploy-gc".to_string());
 
             build_command.arg("--out-link").arg(format!(
                 "{}/{}/{}",
@@ -131,15 +145,21 @@ pub async fn build_profile_locally(
         (false, true) => build_command.arg("--no-link"),
     };
 
+    build_command.args(data.extra_build_args.clone());
+
     build_command
-        .args(data.extra_build_args)
         // Logging should be in stderr, this just stops the store path from printing for no reason
         .stdout(Stdio::null());
 
-    command::Command::new(build_command)
+    let build_status = command::Command::new(build_command)
         .status()
         .await
         .map_err(PushProfileError::Build)?;
+
+    match build_status.code() {
+        Some(0) => (),
+        a => return Err(PushProfileError::BuildExit(a)),
+    };
 
     if !Path::new(
         format!(
@@ -186,8 +206,27 @@ pub async fn build_profile_locally(
     Ok(())
 }
 
+async fn update_pb_with_child_output(pb: &ProgressBar, child: &mut Child) {
+    let stdout = child
+        .stdout
+        .take()
+        .expect("child did not have a stdout handle");
+    let stderr = child
+        .stderr
+        .take()
+        .expect("child did not have a stderr handle");
+
+    let stdout = LinesStream::new(BufReader::new(stdout).lines());
+    let stderr = LinesStream::new(BufReader::new(stderr).lines());
+    let mut merged = StreamExt::merge(stdout, stderr);
+
+    while let Some(line) = merged.next().await {
+        pb.set_message(line.expect("expected a valid line"));
+    }
+}
+
 pub async fn build_profile_remotely(
-    data: &PushProfileData<'_>,
+    data: &PushProfileData,
     derivation_name: &str,
 ) -> Result<(), PushProfileError> {
     info!(
@@ -205,49 +244,79 @@ pub async fn build_profile_remotely(
     let ssh_opts_str = data.deploy_data.merged_settings.ssh_opts.join(" ");
 
     // copy the derivation to remote host so it can be built there
-    let mut copy_command = Command::new("nix");
-    copy_command
-        .arg("--experimental-features")
-        .arg("nix-command")
-        .arg("copy")
-        .arg("-s") // fetch dependencies from substitutes, not localhost
-        .arg("--to")
-        .arg(&store_address)
-        .arg("--derivation")
-        .arg(derivation_name)
-        .env("NIX_SSHOPTS", ssh_opts_str.clone())
-        .stdout(Stdio::null());
-    command::Command::new(copy_command)
-        .status()
-        .await
-        .map_err(PushProfileError::Copy)?;
+    let copy_command_status = {
+        let mut copy_command = Command::new("nix");
+        copy_command
+            .arg("copy")
+            .arg("-s") // fetch dependencies from substitures, not localhost
+            .arg("--to")
+            .arg(&store_address)
+            .arg("--derivation")
+            .arg(derivation_name)
+            .env("NIX_SSHOPTS", ssh_opts_str.clone());
 
-    let mut build_command = Command::new("nix");
-    build_command
-        .arg("--experimental-features")
-        .arg("nix-command")
-        .arg("build")
-        .arg(derivation_name)
-        .arg("--eval-store")
-        .arg("auto")
-        .arg("--store")
-        .arg(&store_address)
-        .args(data.extra_build_args)
-        .env("NIX_SSHOPTS", ssh_opts_str.clone())
-        // Logging should be in stderr, this just stops the store path from printing for no reason
-        .stdout(Stdio::null());
+        debug!("copy command: {:?}", copy_command);
 
-    debug!("build command: {:?}", build_command);
+        let mut child = copy_command
+            .stderr(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("failed to spawn nix copy command");
 
-    command::Command::new(build_command)
-        .status()
-        .await
-        .map_err(PushProfileError::Build)?;
+        if let Some(pb) = &data.deploy_data.progressbar {
+            update_pb_with_child_output(pb, &mut child).await;
+        }
+
+        child
+            .wait()
+            .await
+            .map_err(|e| PushProfileError::Copy(command::CommandError::RunError(e)))?
+    };
+
+    match copy_command_status.code() {
+        Some(0) => (),
+        a => return Err(PushProfileError::CopyExit(a)),
+    };
+
+    let build_exit_status = {
+        let mut build_command = Command::new("nix");
+        build_command
+            .arg("build")
+            .arg(derivation_name)
+            .arg("--eval-store")
+            .arg("auto")
+            .arg("--store")
+            .arg(&store_address)
+            .args(data.extra_build_args.clone())
+            .env("NIX_SSHOPTS", ssh_opts_str.clone());
+
+        debug!("build command: {:?}", build_command);
+
+        let mut child = build_command
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to spawn nix build command");
+
+        if let Some(pb) = &data.deploy_data.progressbar {
+            update_pb_with_child_output(pb, &mut child).await;
+        }
+
+        child
+            .wait()
+            .await
+            .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?
+    };
+
+    match build_exit_status.code() {
+        Some(0) => (),
+        a => return Err(PushProfileError::BuildExit(a)),
+    };
 
     Ok(())
 }
 
-pub async fn build_profile(data: PushProfileData<'_>) -> Result<(), PushProfileError> {
+pub async fn build_profile(data: &PushProfileData) -> Result<(), PushProfileError> {
     debug!(
         "Finding the deriver of store path for {}",
         &data.deploy_data.profile.profile_settings.path
@@ -365,15 +434,15 @@ pub async fn build_profile(data: PushProfileData<'_>) -> Result<(), PushProfileE
             warn!("remote builds using non-flake nix are experimental");
         }
 
-        build_profile_remotely(&data, &deriver).await?;
+        build_profile_remotely(data, &deriver).await?;
     } else {
-        build_profile_locally(&data, &deriver).await?;
+        build_profile_locally(data, &deriver).await?;
     }
 
     Ok(())
 }
 
-pub async fn push_profile(data: PushProfileData<'_>) -> Result<(), PushProfileError> {
+pub async fn push_profile(data: &PushProfileData) -> Result<(), PushProfileError> {
     let ssh_opts_str = data
         .deploy_data
         .merged_settings


### PR DESCRIPTION
NB: I have opened this Pull Request as a *draft* since I intend to continue working on it by improving the logging output.
Since the builds are started concurrently, the build progress information is pretty much useless and flickers a lot.

# Problem

The current implementation builds every single profile synchronously, including remote builds. 
Since remote builds were introduced back in #175, remote builds could be pipelined to deploy
new configurations in a more time-efficient manner.

# Solution

Build configurations that support remote builds concurrently.

---

Sidenote: I have decided to continue building local builds in a synchronous manner because I have run into hardware deadlocks previously when trying to evaluate and/or build multiple systems at the same time.

I have tested this code by deploying to my personal infrastructure (https://github.com/philtaken/dotfiles) and it works as intended.