### PR TITLE
fix nix-build invocation in non-flake builds

### DIFF
--- a/nix/tests/common.nix
+++ b/nix/tests/common.nix
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-{inputs, pkgs, ...}: {
+{inputs, pkgs, flakes, ...}: {
   nix = {
     registry.nixpkgs.flake = inputs.nixpkgs;
+    nixPath = [ "nixpkgs=${inputs.nixpkgs}" ];
     extraOptions = ''
-      experimental-features = nix-command flakes
+      experimental-features = ${if flakes then "nix-command flakes" else "nix-command"}
     '';
     settings = {
       trusted-users = [ "root" "@wheel" ];

--- a/nix/tests/deploy-flake.nix
+++ b/nix/tests/deploy-flake.nix
@@ -15,7 +15,7 @@
   in {
     nixosConfigurations.server = nixpkgs.lib.nixosSystem {
       inherit system pkgs;
-      specialArgs = { inherit inputs; };
+      specialArgs = { inherit inputs; flakes = import inputs.enable-flakes; };
       modules = [
         ./server.nix
         ./common.nix

--- a/src/push.rs
+++ b/src/push.rs
@@ -244,9 +244,13 @@ pub async fn build_profile(data: PushProfileData<'_>) -> Result<(), PushProfileE
         .next()
         .ok_or(PushProfileError::ShowDerivationEmpty)?;
 
-    // Since nix 2.15.0 'nix build <path>.drv' will build only the .drv file itself, not the
-    // derivation outputs, '^out' is used to refer to outputs explicitly
-    let new_deriver = &(deriver.to_owned().to_string() + "^out");
+    let new_deriver = &if data.supports_flakes {
+        // Since nix 2.15.0 'nix build <path>.drv' will build only the .drv file itself, not the
+        // derivation outputs, '^out' is used to refer to outputs explicitly
+        deriver.to_owned().to_string() + "^out"
+    } else {
+        deriver.to_owned()
+    };
 
     let path_info_output = Command::new("nix")
         .arg("--experimental-features").arg("nix-command")


### PR DESCRIPTION
The `drvpath^out` syntax is only part of `nix build`, not `nix-build`. The latter still behaves as before Nix 2.15 and produces the outPath, but produces an error if one attempts to call it the same way as `nix build`.