### PR TITLE
allow --ssh-opts starts with hyphen

### DIFF
--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -131,4 +131,9 @@ in {
     user = "deploy";
     deployArgs = "-s .#profile -- --offline";
   };
+  hyphen-ssh-opts-regression = mkTest {
+    name = "profile";
+    user = "deploy";
+    deployArgs = "-s .#profile --ssh-opts '-p 22 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -- --offline";
+  };
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,7 +68,7 @@ pub struct Opts {
     #[clap(long)]
     profile_user: Option<String>,
     /// Override the SSH options used
-    #[clap(long)]
+    #[clap(long, allow_hyphen_values = true)]
     ssh_opts: Option<String>,
     /// Override if the connecting to the target node should be considered fast
     #[clap(long)]


### PR DESCRIPTION
for example

```sh
deploy .#s --hostname example.com --ssh-opts '-p 1145'
```

without `allow_hyphen_values`:

```
error: Found argument '-p' which wasn't expected, or isn't valid in this context
```

workaround: add a space after quote

```sh
deploy .#s --hostname example.com --ssh-opts ' -p 1145'
```

but it might be better adding `allow_hyphen_values = true`
