### PR TITLE
add meta.mainProgram to rust drv

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,11 @@
           ];
 
           cargoLock.lockFile = ./Cargo.lock;
-        }) // { meta.description = "A Simple multi-profile Nix-flake deploy tool"; };
+	  meta = {
+	    description = "A Simple multi-profile Nix-flake deploy tool"; 
+            mainProgram = "deploy";
+	  };
+        });
 
         lib = rec {
 


### PR DESCRIPTION
Most importantly, this fixes `lib.getExe` and `pkgs.writeShellApplication` not working correctly.
