### PR TITLE
[#260] Show failed nix command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "toml",
+ "unescape",
  "whoami",
  "yn",
 ]
@@ -1084,6 +1085,12 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "unescape"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ toml = "0.8"
 whoami = "1.6"
 yn = "0.1"
 rpassword = "7.3.1"
+unescape = "0.1.0"
 
 
 [lib]

--- a/src/bin/activate.rs
+++ b/src/bin/activate.rs
@@ -431,19 +431,21 @@ pub async fn activate(
             .arg(&profile_path)
             .arg("--set")
             .arg(&closure);
-        let nix_env_set_exit_status = nix_env_set_command
-            .status()
+        let nix_env_set_exit_output = nix_env_set_command
+            .output()
             .await
             .map_err(|err| {
                 ActivateError::SetProfile(command::CommandError::RunError(err))
             })?;
-        match nix_env_set_exit_status.code() {
+        match nix_env_set_exit_output.status.code() {
             Some(0) => (),
-            a => {
+            _exit_code => {
                 if auto_rollback && !dry_activate {
                     deactivate(&profile_path).await?;
                 }
-                return Err(ActivateError::SetProfile(command::CommandError::Exit(a, format!("{:?}", nix_env_set_command))));
+                return Err(ActivateError::SetProfile(
+                    command::CommandError::Exit(nix_env_set_exit_output, format!("{:?}", nix_env_set_command))
+                ));
             }
         };
     }
@@ -462,8 +464,8 @@ pub async fn activate(
         .env("DRY_ACTIVATE", if dry_activate { "1" } else { "0" })
         .env("BOOT", if boot { "1" } else { "0" })
         .current_dir(activation_location);
-    let activate_status = match activate_command
-        .status()
+    let activate_output = match activate_command
+        .output()
         .await
         .map_err(|err| {
             ActivateError::RunActivate(command::CommandError::RunError(err))
@@ -479,13 +481,15 @@ pub async fn activate(
     };
 
     if !dry_activate {
-        match activate_status.code() {
+        match activate_output.status.code() {
             Some(0) => (),
-            a => {
+            _exit_code => {
                 if auto_rollback {
                     deactivate(&profile_path).await?;
                 }
-                return Err(ActivateError::RunActivate(command::CommandError::Exit(a, format!("{:?}", activate_command))));
+                return Err(ActivateError::RunActivate(
+                    command::CommandError::Exit(activate_output, format!("{:?}", activate_command))
+                ));
             }
         };
 

--- a/src/bin/activate.rs
+++ b/src/bin/activate.rs
@@ -24,6 +24,8 @@ use thiserror::Error;
 
 use log::{debug, error, info, warn};
 
+use deploy::command;
+
 /// Remote activation utility for deploy-rs
 #[derive(Parser, Debug)]
 #[command(version = "1.0", author = "Serokell <https://serokell.io/>")]
@@ -122,25 +124,53 @@ struct RevokeOpts {
 }
 
 #[derive(Error, Debug)]
+pub enum RollbackError {}
+
+impl command::HasCommandError for RollbackError {
+    fn title() -> String {
+        "Nix rollback".to_string()
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ListGenError {}
+
+impl command::HasCommandError for ListGenError {
+    fn title() -> String {
+        "Nix list generations".to_string()
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum DeleteGenError {}
+
+impl command::HasCommandError for DeleteGenError {
+    fn title() -> String {
+        "Nix delete generations".to_string()
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ReactivateError {}
+
+impl command::HasCommandError for ReactivateError {
+    fn title() -> String {
+        "Nix reactivate last generation".to_string()
+    }
+}
+
+#[derive(Error, Debug)]
 pub enum DeactivateError {
-    #[error("Failed to execute the rollback command: {0}")]
-    Rollback(std::io::Error),
-    #[error("The rollback resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
-    RollbackExit(Option<i32>, String),
-    #[error("Failed to run command for listing generations: {0}")]
-    ListGen(std::io::Error),
-    #[error("Command for listing generations resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
-    ListGenExit(Option<i32>, String),
+    #[error("{0}")]
+    Rollback(#[from] command::CommandError<RollbackError>),
+    #[error("{0}")]
+    ListGen(#[from] command::CommandError<ListGenError>),
     #[error("Error converting generation list output to utf8: {0}")]
     DecodeListGenUtf8(std::string::FromUtf8Error),
-    #[error("Failed to run command for deleting generation: {0}")]
-    DeleteGen(std::io::Error),
-    #[error("Command for deleting generations resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
-    DeleteGenExit(Option<i32>, String),
-    #[error("Failed to run command for re-activating the last generation: {0}")]
-    Reactivate(std::io::Error),
-    #[error("Command for re-activating the last generation resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
-    ReactivateExit(Option<i32>, String),
+    #[error("{0}")]
+    DeleteGen(#[from] command::CommandError<DeleteGenError>),
+    #[error("{0}")]
+    Reactivate(#[from] command::CommandError<ReactivateError>),
 }
 
 pub async fn deactivate(profile_path: &str) -> Result<(), DeactivateError> {
@@ -151,15 +181,10 @@ pub async fn deactivate(profile_path: &str) -> Result<(), DeactivateError> {
         .arg("-p")
         .arg(&profile_path)
         .arg("--rollback");
-    let nix_env_rollback_exit_status = nix_env_rollback_command
-        .status()
+    command::Command::new(nix_env_rollback_command)
+        .run()
         .await
         .map_err(DeactivateError::Rollback)?;
-
-    match nix_env_rollback_exit_status.code() {
-        Some(0) => (),
-        a => return Err(DeactivateError::RollbackExit(a, format!("{:?}", nix_env_rollback_command))),
-    };
 
     debug!("Listing generations");
 
@@ -168,15 +193,10 @@ pub async fn deactivate(profile_path: &str) -> Result<(), DeactivateError> {
         .arg("-p")
         .arg(&profile_path)
         .arg("--list-generations");
-    let nix_env_list_generations_out = nix_env_list_generations_command
-        .output()
+    let nix_env_list_generations_out = command::Command::new(nix_env_list_generations_command)
+        .run()
         .await
         .map_err(DeactivateError::ListGen)?;
-
-    match nix_env_list_generations_out.status.code() {
-        Some(0) => (),
-        a => return Err(DeactivateError::ListGenExit(a, format!("{:?}", nix_env_list_generations_command))),
-    };
 
     let generations_list = String::from_utf8(nix_env_list_generations_out.stdout)
         .map_err(DeactivateError::DecodeListGenUtf8)?;
@@ -200,15 +220,10 @@ pub async fn deactivate(profile_path: &str) -> Result<(), DeactivateError> {
         .arg(&profile_path)
         .arg("--delete-generations")
         .arg(last_generation_id);
-    let nix_env_delete_generation_exit_status = nix_env_delete_generation_command
-        .status()
+    command::Command::new(nix_env_delete_generation_command)
+        .run()
         .await
         .map_err(DeactivateError::DeleteGen)?;
-
-    match nix_env_delete_generation_exit_status.code() {
-        Some(0) => (),
-        a => return Err(DeactivateError::DeleteGenExit(a, format!("{:?}", nix_env_list_generations_command))),
-    };
 
     info!("Attempting to re-activate the last generation");
 
@@ -216,15 +231,10 @@ pub async fn deactivate(profile_path: &str) -> Result<(), DeactivateError> {
     re_activate_command
         .env("PROFILE", &profile_path)
         .current_dir(&profile_path);
-    let re_activate_exit_status = re_activate_command
-        .status()
+    command::Command::new(re_activate_command)
+        .run()
         .await
         .map_err(DeactivateError::Reactivate)?;
-
-    match re_activate_exit_status.code() {
-        Some(0) => (),
-        a => return Err(DeactivateError::ReactivateExit(a,format!("{:?}", re_activate_command))),
-    };
 
     Ok(())
 }
@@ -371,16 +381,30 @@ pub async fn wait(temp_path: PathBuf, closure: String, activation_timeout: Optio
 }
 
 #[derive(Error, Debug)]
-pub enum ActivateError {
-    #[error("Failed to execute the command for setting profile: {0}")]
-    SetProfile(std::io::Error),
-    #[error("The command for setting profile resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
-    SetProfileExit(Option<i32>, String),
+pub enum SetProfileError {}
 
-    #[error("Failed to execute the activation script: {0}")]
-    RunActivate(std::io::Error),
-    #[error("The activation script resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
-    RunActivateExit(Option<i32>, String),
+impl command::HasCommandError for SetProfileError {
+    fn title() -> String {
+        "Nix profile set".to_string()
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum RunActivateError {}
+
+impl command::HasCommandError for RunActivateError {
+    fn title() -> String {
+        "Nix activation script".to_string()
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ActivateError {
+    #[error("{0}")]
+    SetProfile(#[from] command::CommandError<SetProfileError>),
+
+    #[error("{0}")]
+    RunActivate(#[from] command::CommandError<RunActivateError>),
 
     #[error("There was an error de-activating after an error was encountered: {0}")]
     Deactivate(#[from] DeactivateError),
@@ -410,14 +434,16 @@ pub async fn activate(
         let nix_env_set_exit_status = nix_env_set_command
             .status()
             .await
-            .map_err(ActivateError::SetProfile)?;
+            .map_err(|err| {
+                ActivateError::SetProfile(command::CommandError::RunError(err))
+            })?;
         match nix_env_set_exit_status.code() {
             Some(0) => (),
             a => {
                 if auto_rollback && !dry_activate {
                     deactivate(&profile_path).await?;
                 }
-                return Err(ActivateError::SetProfileExit(a,format!("{:?}", nix_env_set_command)));
+                return Err(ActivateError::SetProfile(command::CommandError::Exit(a, format!("{:?}", nix_env_set_command))));
             }
         };
     }
@@ -439,7 +465,9 @@ pub async fn activate(
     let activate_status = match activate_command
         .status()
         .await
-        .map_err(ActivateError::RunActivate)
+        .map_err(|err| {
+            ActivateError::RunActivate(command::CommandError::RunError(err))
+        })
     {
         Ok(x) => x,
         Err(e) => {
@@ -457,7 +485,7 @@ pub async fn activate(
                 if auto_rollback {
                     deactivate(&profile_path).await?;
                 }
-                return Err(ActivateError::RunActivateExit(a, format!("{:?}", activate_command)));
+                return Err(ActivateError::RunActivate(command::CommandError::Exit(a, format!("{:?}", activate_command))));
             }
         };
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -386,9 +386,9 @@ fn prompt_deployment(
 pub enum RunDeployError {
     #[error("Failed to deploy profile to node {0}: {1}")]
     DeployProfile(String, deploy::deploy::DeployProfileError),
-    #[error("Failed to build profile on node {0}: {0}")]
+    #[error("Failed to build profile on node {0}: {1}")]
     BuildProfile(String,  deploy::push::PushProfileError),
-    #[error("Failed to push profile to node {0}: {0}")]
+    #[error("Failed to push profile to node {0}: {1}")]
     PushProfile(String,  deploy::push::PushProfileError),
     #[error("No profile named `{0}` was found")]
     ProfileNotFound(String),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,7 @@ use std::io::{stdin, stdout, Write};
 use clap::{ArgMatches, Parser, FromArgMatches};
 
 use crate as deploy;
+use crate::command;
 
 use self::deploy::{DeployFlake, ParseFlakeError};
 use futures_util::stream::{StreamExt, TryStreamExt};
@@ -129,11 +130,18 @@ async fn test_flake_support() -> Result<bool, std::io::Error> {
 }
 
 #[derive(Error, Debug)]
+pub enum NixCheckError {}
+
+impl command::HasCommandError for NixCheckError {
+    fn title() -> String {
+        "Nix checking".to_string()
+    }
+}
+
+#[derive(Error, Debug)]
 pub enum CheckDeploymentError {
-    #[error("Failed to execute Nix checking command: {0}")]
-    NixCheck(#[from] std::io::Error),
-    #[error("Nix checking command resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
-    NixCheckExit(Option<i32>, String),
+    #[error("{0}")]
+    NixCheck(#[from] command::CommandError<NixCheckError>),
 }
 
 async fn check_deployment(
@@ -158,24 +166,24 @@ async fn check_deployment(
 
     check_command.args(extra_build_args);
 
-    let check_status = check_command.status().await?;
-
-    match check_status.code() {
-        Some(0) => (),
-        a => return Err(CheckDeploymentError::NixCheckExit(a, format!("{:?}", check_command))),
-    };
+    command::Command::new(check_command).run().await.map_err(CheckDeploymentError::NixCheck)?;
 
     Ok(())
 }
 
 #[derive(Error, Debug)]
+pub enum NixEvalError {}
+
+impl command::HasCommandError for NixEvalError {
+    fn title() -> String {
+        "Nix eval".to_string()
+    }
+}
+
+#[derive(Error, Debug)]
 pub enum GetDeploymentDataError {
-    #[error("Failed to execute nix eval command: {0}")]
-    NixEval(std::io::Error),
-    #[error("Failed to read output from evaluation: {0}")]
-    NixEvalOut(std::io::Error),
-    #[error("Evaluation resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
-    NixEvalExit(Option<i32>, String),
+    #[error("{0}")]
+    NixEval(#[from] command::CommandError<NixEvalError>),
     #[error("Error converting evaluation output to utf8: {0}")]
     DecodeUtf8(#[from] std::string::FromUtf8Error),
     #[error("Error decoding the JSON from evaluation: {0}")]
@@ -255,22 +263,14 @@ async fn get_deployment_data(
             .arg(format!("let r = import {}/.; in if builtins.isFunction r then (r {{}}).deploy else r.deploy", flake.repo))
     };
 
-    eval_command.args(extra_build_args);
+    eval_command
+        .args(extra_build_args)
+        .stdout(Stdio::piped());
 
-    let build_child = eval_command
-        .stdout(Stdio::piped())
-        .spawn()
-        .map_err(GetDeploymentDataError::NixEval)?;
-
-    let build_output = build_child
-        .wait_with_output()
+    let build_output = command::Command::new(eval_command)
+        .run()
         .await
-        .map_err(GetDeploymentDataError::NixEvalOut)?;
-
-    match build_output.status.code() {
-        Some(0) => (),
-        a => return Err(GetDeploymentDataError::NixEvalExit(a, format!("{:?}", eval_command))),
-    };
+        .map_err(GetDeploymentDataError::NixEval)?;
 
     let data_json = String::from_utf8(build_output.stdout)?;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -132,8 +132,8 @@ async fn test_flake_support() -> Result<bool, std::io::Error> {
 pub enum CheckDeploymentError {
     #[error("Failed to execute Nix checking command: {0}")]
     NixCheck(#[from] std::io::Error),
-    #[error("Nix checking command resulted in a bad exit code: {0:?}")]
-    NixCheckExit(Option<i32>),
+    #[error("Nix checking command resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
+    NixCheckExit(Option<i32>, String),
 }
 
 async fn check_deployment(
@@ -162,7 +162,7 @@ async fn check_deployment(
 
     match check_status.code() {
         Some(0) => (),
-        a => return Err(CheckDeploymentError::NixCheckExit(a)),
+        a => return Err(CheckDeploymentError::NixCheckExit(a, format!("{:?}", check_command))),
     };
 
     Ok(())
@@ -174,8 +174,8 @@ pub enum GetDeploymentDataError {
     NixEval(std::io::Error),
     #[error("Failed to read output from evaluation: {0}")]
     NixEvalOut(std::io::Error),
-    #[error("Evaluation resulted in a bad exit code: {0:?}")]
-    NixEvalExit(Option<i32>),
+    #[error("Evaluation resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
+    NixEvalExit(Option<i32>, String),
     #[error("Error converting evaluation output to utf8: {0}")]
     DecodeUtf8(#[from] std::string::FromUtf8Error),
     #[error("Error decoding the JSON from evaluation: {0}")]
@@ -194,14 +194,14 @@ async fn get_deployment_data(
 
     info!("Evaluating flake in {}", flake.repo);
 
-    let mut c = if supports_flakes {
+    let mut eval_command = if supports_flakes {
         Command::new("nix")
     } else {
         Command::new("nix-instantiate")
     };
 
     if supports_flakes {
-        c.arg("eval")
+        eval_command.arg("eval")
             .arg("--json")
             .arg(format!("{}#deploy", flake.repo))
             // We use --apply instead of --expr so that we don't have to deal with builtins.getFlake
@@ -209,7 +209,7 @@ async fn get_deployment_data(
         match (&flake.node, &flake.profile) {
             (Some(node), Some(profile)) => {
                 // Ignore all nodes and all profiles but the one we're evaluating
-                c.arg(format!(
+                eval_command.arg(format!(
                     r#"
                       deploy:
                       (deploy // {{
@@ -227,7 +227,7 @@ async fn get_deployment_data(
             }
             (Some(node), None) => {
                 // Ignore all nodes but the one we're evaluating
-                c.arg(format!(
+                eval_command.arg(format!(
                     r#"
                       deploy:
                       (deploy // {{
@@ -241,12 +241,12 @@ async fn get_deployment_data(
             }
             (None, None) => {
                 // We need to evaluate all profiles of all nodes anyway, so just do it strictly
-                c.arg("deploy: deploy")
+                eval_command.arg("deploy: deploy")
             }
             (None, Some(_)) => return Err(GetDeploymentDataError::ProfileNoNode),
         }
     } else {
-        c
+        eval_command
             .arg("--strict")
             .arg("--read-write-mode")
             .arg("--json")
@@ -255,9 +255,9 @@ async fn get_deployment_data(
             .arg(format!("let r = import {}/.; in if builtins.isFunction r then (r {{}}).deploy else r.deploy", flake.repo))
     };
 
-    c.args(extra_build_args);
+    eval_command.args(extra_build_args);
 
-    let build_child = c
+    let build_child = eval_command
         .stdout(Stdio::piped())
         .spawn()
         .map_err(GetDeploymentDataError::NixEval)?;
@@ -269,7 +269,7 @@ async fn get_deployment_data(
 
     match build_output.status.code() {
         Some(0) => (),
-        a => return Err(GetDeploymentDataError::NixEvalExit(a)),
+        a => return Err(GetDeploymentDataError::NixEvalExit(a, format!("{:?}", eval_command))),
     };
 
     let data_json = String::from_utf8(build_output.stdout)?;

--- a/src/command.rs
+++ b/src/command.rs
@@ -10,26 +10,30 @@ pub trait HasCommandError {
 #[derive(Error, Debug)]
 pub enum CommandError<T: fmt::Debug + fmt::Display + HasCommandError> {
     RunError(std::io::Error),
-    Exit(Option<i32>, String),
+    Exit(std::process::Output, String),
     OtherError(T),
 }
 
 impl<T: fmt::Debug + fmt::Display + HasCommandError> fmt::Display for CommandError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            CommandError::RunError(err) => write!(
-                f,
-                "Failed to run {} command: {}",
-                T::title(),
-                err,
-            ),
-            CommandError::Exit(exit_code, cmd) => write!(
-                f,
-                "{} command resulted in a bad exit code: {:?}. The failed command is provided below:\n{}",
-                T::title(),
-                exit_code,
-                cmd,
-            ),
+            CommandError::RunError(err) => {
+                write!(f, "Failed to run {} command: {}", T::title(), err,)
+            }
+            CommandError::Exit(output, cmd) => {
+                let stderr = match String::from_utf8(output.stderr.clone()) {
+                    Ok(stderr) => stderr,
+                    Err(_err) => format!("{:?}", output.stderr),
+                };
+                write!(
+                    f,
+                    "{} command resulted in a bad exit code: {:?}. The failed command is provided below:\n{}\nThe stderr output is provided below:\n{}",
+                    T::title(),
+                    output.status.code(),
+                    cmd,
+                    stderr,
+                )
+            }
             CommandError::OtherError(err) => write!(f, "{}", err),
         }
     }
@@ -56,7 +60,7 @@ impl Command {
             .map_err(CommandError::RunError)?;
         match output.status.code() {
             Some(0) => Ok(output),
-            exit_code => Err(CommandError::Exit(exit_code, format!("{:?}", self.command))),
+            _exit_code => Err(CommandError::Exit(output, format!("{:?}", self.command))),
         }
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -30,7 +30,7 @@ impl<T: fmt::Debug + fmt::Display + HasCommandError> fmt::Display for CommandErr
                     "{} command resulted in a bad exit code: {:?}. The failed command is provided below:\n{}\nThe stderr output is provided below:\n{}",
                     T::title(),
                     output.status.code(),
-                    cmd,
+                    unescape::unescape(cmd).unwrap_or(cmd.clone()),
                     stderr,
                 )
             }
@@ -46,8 +46,8 @@ pub struct Command {
 }
 
 impl Command {
-    pub fn new(command: TokioCommand) -> Command {
-        Command { command }
+    pub fn new(command: TokioCommand) -> Self {
+        Self { command }
     }
 
     pub async fn run<T: fmt::Debug + fmt::Display + HasCommandError>(

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,68 @@
+use std::fmt;
+use std::fmt::Debug;
+use thiserror::Error;
+use tokio::process::Command as TokioCommand;
+
+pub trait HasCommandError {
+    fn title() -> String;
+}
+
+#[derive(Error, Debug)]
+pub enum CommandError<T: fmt::Debug + fmt::Display + HasCommandError> {
+    RunError(std::io::Error),
+    Exit(Option<i32>, String),
+    OtherError(T),
+}
+
+impl<T: fmt::Debug + fmt::Display + HasCommandError> fmt::Display for CommandError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CommandError::RunError(err) => write!(
+                f,
+                "Failed to run {} command: {}",
+                T::title(),
+                err,
+            ),
+            CommandError::Exit(exit_code, cmd) => write!(
+                f,
+                "{} command resulted in a bad exit code: {:?}. The failed command is provided below:\n{}",
+                T::title(),
+                exit_code,
+                cmd,
+            ),
+            CommandError::OtherError(err) => write!(f, "{}", err),
+        }
+    }
+}
+
+/// A wrapper over `tokio::process::Command` to provide the `run` method commonly used by `deploy`.
+#[derive(Debug)]
+pub struct Command {
+    pub command: TokioCommand,
+}
+
+impl Command {
+    pub fn new(command: TokioCommand) -> Command {
+        Command { command }
+    }
+
+    pub async fn run<T: fmt::Debug + fmt::Display + HasCommandError>(
+        &mut self,
+    ) -> Result<std::process::Output, CommandError<T>> {
+        let output = self
+            .command
+            .output()
+            .await
+            .map_err(CommandError::RunError)?;
+        match output.status.code() {
+            Some(0) => Ok(output),
+            exit_code => Err(CommandError::Exit(exit_code, format!("{:?}", self.command))),
+        }
+    }
+}
+
+impl fmt::Display for Command {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.command.fmt(f)
+    }
+}

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -327,16 +327,19 @@ pub async fn confirm_profile(
             .map_err(|err| ConfirmProfileError::SSHConfirm(command::CommandError::RunError(err)))?;
     }
 
-    let ssh_confirm_exit_status = ssh_confirm_child
-        .wait()
+    let ssh_confirm_exit_output = ssh_confirm_child
+        .wait_with_output()
         .await
         .map_err(|err| ConfirmProfileError::SSHConfirm(command::CommandError::RunError(err)))?;
 
-    match ssh_confirm_exit_status.code() {
+    match ssh_confirm_exit_output.status.code() {
         Some(0) => (),
-        a => {
+        _exit_code => {
             return Err(ConfirmProfileError::SSHConfirm(
-                command::CommandError::Exit(a, format!("{:?}", ssh_confirm_command)),
+                command::CommandError::Exit(
+                    ssh_confirm_exit_output,
+                    format!("{:?}", ssh_confirm_command),
+                ),
             ))
         }
     };
@@ -469,15 +472,18 @@ pub async fn deploy_profile(
         }
 
         let ssh_activate_exit_status = ssh_activate_child
-            .wait()
+            .wait_with_output()
             .await
             .map_err(|err| DeployProfileError::SSHActivate(command::CommandError::RunError(err)))?;
 
-        match ssh_activate_exit_status.code() {
+        match ssh_activate_exit_status.status.code() {
             Some(0) => (),
-            exit_code => {
+            _exit_code => {
                 return Err(DeployProfileError::SSHActivate(
-                    command::CommandError::Exit(exit_code, format!("{:?}", ssh_activate_command)),
+                    command::CommandError::Exit(
+                        ssh_activate_exit_status,
+                        format!("{:?}", ssh_activate_command),
+                    ),
                 ))
             }
         };
@@ -548,8 +554,11 @@ pub async fn deploy_profile(
                 )),
                 Ok(ref x) => match x.status.code() {
                     Some(0) => None,
-                    a => Some(DeployProfileError::SSHActivate(
-                        command::CommandError::Exit(a, format!("{:?}", ssh_activate_command)),
+                    _exit_code => Some(DeployProfileError::SSHActivate(
+                        command::CommandError::Exit(
+                            x.clone(),
+                            format!("{:?}", ssh_activate_command),
+                        ),
                     )),
                 },
             };
@@ -582,12 +591,13 @@ pub async fn deploy_profile(
         }
 
         tokio::select! {
-            x = ssh_wait_child.wait() => {
+            x = ssh_wait_child.wait_with_output() => {
                 debug!("Wait command ended");
-                match x.map_err(|err| DeployProfileError::SSHWait(command::CommandError::RunError(err)))?.code() {
+                let output = x.map_err(|err| DeployProfileError::SSHWait(command::CommandError::RunError(err)))?;
+                match output.status.code() {
                     Some(0) => (),
-                    a => return Err(DeployProfileError::SSHWait(
-                        command::CommandError::Exit(a, format!("{:?}", ssh_wait_command))
+                    _exit_code => return Err(DeployProfileError::SSHWait(
+                        command::CommandError::Exit(output, format!("{:?}", ssh_wait_command))
                     )),
                 };
             },
@@ -693,8 +703,8 @@ pub async fn revoke(
         )),
         Ok(ref x) => match x.status.code() {
             Some(0) => Ok(()),
-            a => Err(RevokeProfileError::SSHRevoke(command::CommandError::Exit(
-                a,
+            _exit_code => Err(RevokeProfileError::SSHRevoke(command::CommandError::Exit(
+                x.clone(),
                 format!("{:?}", ssh_activate_command),
             ))),
         },

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use thiserror::Error;
 use tokio::{io::AsyncWriteExt, process::Command};
 
-use crate::{DeployDataDefsError, DeployDefs, ProfileInfo};
+use crate::{command, DeployDataDefsError, DeployDefs, ProfileInfo};
 
 struct ActivateCommandData<'a> {
     sudo: &'a Option<String>,
@@ -144,7 +144,10 @@ fn build_wait_command(data: &WaitCommandData) -> String {
         data.temp_path.display(),
     );
     if let Some(activation_timeout) = data.activation_timeout {
-        self_activate_command = format!("{} --activation-timeout {}", self_activate_command, activation_timeout);
+        self_activate_command = format!(
+            "{} --activation-timeout {}",
+            self_activate_command, activation_timeout
+        );
     }
 
     if let Some(sudo_cmd) = &data.sudo {
@@ -242,31 +245,43 @@ fn test_revoke_command_builder() {
     );
 }
 
-async fn handle_sudo_stdin(ssh_activate_child: &mut tokio::process::Child, deploy_defs: &DeployDefs) -> Result<(), std::io::Error> {
+async fn handle_sudo_stdin(
+    ssh_activate_child: &mut tokio::process::Child,
+    deploy_defs: &DeployDefs,
+) -> Result<(), std::io::Error> {
     match ssh_activate_child.stdin.as_mut() {
         Some(stdin) => {
-            let _ = stdin.write_all(format!("{}\n",deploy_defs.sudo_password.clone().unwrap_or("".to_string())).as_bytes()).await;
+            let _ = stdin
+                .write_all(
+                    format!(
+                        "{}\n",
+                        deploy_defs.sudo_password.clone().unwrap_or("".to_string())
+                    )
+                    .as_bytes(),
+                )
+                .await;
             Ok(())
         }
-        None => {
-            Err(
-                std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "Failed to open stdin for sudo command",
-                )
-            )
-        }
+        None => Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "Failed to open stdin for sudo command",
+        )),
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum SSHConfirmError {}
+
+impl command::HasCommandError for SSHConfirmError {
+    fn title() -> String {
+        "SSH confirmation command (the server should roll back)".to_string()
     }
 }
 
 #[derive(Error, Debug)]
 pub enum ConfirmProfileError {
-    #[error("Failed to run confirmation command over SSH (the server should roll back): {0}")]
-    SSHConfirm(std::io::Error),
-    #[error(
-        "Confirming activation over SSH resulted in a bad exit code (the server should roll back): {0:?}. The failed command is provided below:\n{1}"
-    )]
-    SSHConfirmExit(Option<i32>, String),
+    #[error("{0}")]
+    SSHConfirm(#[from] command::CommandError<SSHConfirmError>),
 }
 
 pub async fn confirm_profile(
@@ -299,23 +314,31 @@ pub async fn confirm_profile(
     let mut ssh_confirm_child = ssh_confirm_command
         .arg(confirm_command)
         .spawn()
-        .map_err(ConfirmProfileError::SSHConfirm)?;
-    
-    if deploy_data.merged_settings.interactive_sudo.unwrap_or(false) {
+        .map_err(|err| ConfirmProfileError::SSHConfirm(command::CommandError::RunError(err)))?;
+
+    if deploy_data
+        .merged_settings
+        .interactive_sudo
+        .unwrap_or(false)
+    {
         trace!("[confirm] Piping in sudo password");
         handle_sudo_stdin(&mut ssh_confirm_child, deploy_defs)
             .await
-            .map_err(ConfirmProfileError::SSHConfirm)?;
+            .map_err(|err| ConfirmProfileError::SSHConfirm(command::CommandError::RunError(err)))?;
     }
 
     let ssh_confirm_exit_status = ssh_confirm_child
         .wait()
         .await
-        .map_err(ConfirmProfileError::SSHConfirm)?; 
+        .map_err(|err| ConfirmProfileError::SSHConfirm(command::CommandError::RunError(err)))?;
 
     match ssh_confirm_exit_status.code() {
         Some(0) => (),
-        a => return Err(ConfirmProfileError::SSHConfirmExit(a, format!("{:?}", ssh_confirm_command))),
+        a => {
+            return Err(ConfirmProfileError::SSHConfirm(
+                command::CommandError::Exit(a, format!("{:?}", ssh_confirm_command)),
+            ))
+        }
     };
 
     info!("Deployment confirmed.");
@@ -324,24 +347,37 @@ pub async fn confirm_profile(
 }
 
 #[derive(Error, Debug)]
-pub enum DeployProfileError {
+pub enum SSHActivateError {
     #[error("Failed to spawn activation command over SSH: {0}")]
-    SSHSpawnActivate(std::io::Error),
-
-    #[error("Failed to run activation command over SSH: {0}")]
-    SSHActivate(std::io::Error),
-    #[error("Activating over SSH resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
-    SSHActivateExit(Option<i32>, String),
-    #[error("Activating over SSH resulted in a bad exit code: {0:?}")]
-    SSHActivateTimeout(tokio::sync::oneshot::error::RecvError),
-
-    #[error("Failed to run wait command over SSH: {0}")]
-    SSHWait(std::io::Error),
-    #[error("Waiting over SSH resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
-    SSHWaitExit(Option<i32>, String),
-
+    OtherError(std::io::Error),
     #[error("Failed to pipe to child stdin: {0}")]
-    SSHActivatePipe(std::io::Error),
+    PipeError(std::io::Error),
+    #[error("Activating over SSH resulted in a bad exit code: {0:?}")]
+    Timeout(tokio::sync::oneshot::error::RecvError),
+}
+
+impl command::HasCommandError for SSHActivateError {
+    fn title() -> String {
+        "SSH activation command".to_string()
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum SSHWaitError {}
+
+impl command::HasCommandError for SSHWaitError {
+    fn title() -> String {
+        "SSH wait command".to_string()
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum DeployProfileError {
+    #[error("{0}")]
+    SSHActivate(#[from] command::CommandError<SSHActivateError>),
+
+    #[error("{0}")]
+    SSHWait(#[from] command::CommandError<SSHWaitError>),
 
     #[error("Error confirming deployment: {0}")]
     Confirm(#[from] ConfirmProfileError),
@@ -411,23 +447,39 @@ pub async fn deploy_profile(
         let mut ssh_activate_child = ssh_activate_command
             .arg(self_activate_command)
             .spawn()
-            .map_err(DeployProfileError::SSHSpawnActivate)?;
+            .map_err(|err| {
+                DeployProfileError::SSHActivate(command::CommandError::OtherError(
+                    SSHActivateError::OtherError(err),
+                ))
+            })?;
 
-        if deploy_data.merged_settings.interactive_sudo.unwrap_or(false) {
+        if deploy_data
+            .merged_settings
+            .interactive_sudo
+            .unwrap_or(false)
+        {
             trace!("[activate] Piping in sudo password");
             handle_sudo_stdin(&mut ssh_activate_child, deploy_defs)
                 .await
-                .map_err(DeployProfileError::SSHActivatePipe)?;
+                .map_err(|err| {
+                    DeployProfileError::SSHActivate(command::CommandError::OtherError(
+                        SSHActivateError::PipeError(err),
+                    ))
+                })?;
         }
 
         let ssh_activate_exit_status = ssh_activate_child
             .wait()
             .await
-            .map_err(DeployProfileError::SSHActivate)?;
+            .map_err(|err| DeployProfileError::SSHActivate(command::CommandError::RunError(err)))?;
 
         match ssh_activate_exit_status.code() {
             Some(0) => (),
-            a => return Err(DeployProfileError::SSHActivateExit(a, format!("{:?}", ssh_activate_command))),
+            exit_code => {
+                return Err(DeployProfileError::SSHActivate(
+                    command::CommandError::Exit(exit_code, format!("{:?}", ssh_activate_command)),
+                ))
+            }
         };
 
         if dry_activate {
@@ -452,13 +504,25 @@ pub async fn deploy_profile(
         let mut ssh_activate_child = ssh_activate_command
             .arg(self_activate_command)
             .spawn()
-            .map_err(DeployProfileError::SSHSpawnActivate)?;
+            .map_err(|err| {
+                DeployProfileError::SSHActivate(command::CommandError::OtherError(
+                    SSHActivateError::OtherError(err),
+                ))
+            })?;
 
-        if deploy_data.merged_settings.interactive_sudo.unwrap_or(false) {
+        if deploy_data
+            .merged_settings
+            .interactive_sudo
+            .unwrap_or(false)
+        {
             trace!("[activate] Piping in sudo password");
             handle_sudo_stdin(&mut ssh_activate_child, deploy_defs)
                 .await
-                .map_err(DeployProfileError::SSHActivatePipe)?;
+                .map_err(|err| {
+                    DeployProfileError::SSHActivate(command::CommandError::OtherError(
+                        SSHActivateError::PipeError(err),
+                    ))
+                })?;
         }
 
         info!("Creating activation waiter");
@@ -467,7 +531,7 @@ pub async fn deploy_profile(
         ssh_wait_command
             .arg(&ssh_addr)
             .stdin(std::process::Stdio::piped());
-        
+
         for ssh_opt in &deploy_data.merged_settings.ssh_opts {
             ssh_wait_command.arg(ssh_opt);
         }
@@ -479,10 +543,14 @@ pub async fn deploy_profile(
             let o = ssh_activate_child.wait_with_output().await;
 
             let maybe_err = match o {
-                Err(x) => Some(DeployProfileError::SSHActivate(x)),
+                Err(x) => Some(DeployProfileError::SSHActivate(
+                    command::CommandError::RunError(x),
+                )),
                 Ok(ref x) => match x.status.code() {
                     Some(0) => None,
-                    a => Some(DeployProfileError::SSHActivateExit(a, format!("{:?}", ssh_activate_command))),
+                    a => Some(DeployProfileError::SSHActivate(
+                        command::CommandError::Exit(a, format!("{:?}", ssh_activate_command)),
+                    )),
                 },
             };
 
@@ -496,21 +564,31 @@ pub async fn deploy_profile(
         let mut ssh_wait_child = ssh_wait_command
             .arg(self_wait_command)
             .spawn()
-            .map_err(DeployProfileError::SSHWait)?;
+            .map_err(|err| DeployProfileError::SSHWait(command::CommandError::RunError(err)))?;
 
-        if deploy_data.merged_settings.interactive_sudo.unwrap_or(false) {
+        if deploy_data
+            .merged_settings
+            .interactive_sudo
+            .unwrap_or(false)
+        {
             trace!("[wait] Piping in sudo password");
             handle_sudo_stdin(&mut ssh_wait_child, deploy_defs)
                 .await
-                .map_err(DeployProfileError::SSHActivatePipe)?;
+                .map_err(|err| {
+                    DeployProfileError::SSHActivate(command::CommandError::OtherError(
+                        SSHActivateError::PipeError(err),
+                    ))
+                })?;
         }
 
         tokio::select! {
             x = ssh_wait_child.wait() => {
                 debug!("Wait command ended");
-                match x.map_err(DeployProfileError::SSHWait)?.code() {
+                match x.map_err(|err| DeployProfileError::SSHWait(command::CommandError::RunError(err)))?.code() {
                     Some(0) => (),
-                    a => return Err(DeployProfileError::SSHWaitExit(a, format!("{:?}", ssh_wait_command))),
+                    a => return Err(DeployProfileError::SSHWait(
+                        command::CommandError::Exit(a, format!("{:?}", ssh_wait_command))
+                    )),
                 };
             },
             x = recv_activate => {
@@ -522,26 +600,37 @@ pub async fn deploy_profile(
         info!("Success activating, attempting to confirm activation");
 
         let c = confirm_profile(deploy_data, deploy_defs, temp_path, &ssh_addr).await;
-        recv_activated.await.map_err(|x| DeployProfileError::SSHActivateTimeout(x))?;
+        recv_activated.await.map_err(|x| {
+            DeployProfileError::SSHActivate(command::CommandError::OtherError(
+                SSHActivateError::Timeout(x),
+            ))
+        })?;
         c?;
 
-        thread
-            .await
-            .map_err(|x| DeployProfileError::SSHActivate(x.into()))?;
+        thread.await.map_err(|x| {
+            DeployProfileError::SSHActivate(command::CommandError::RunError(x.into()))
+        })?;
     }
 
     Ok(())
 }
 
 #[derive(Error, Debug)]
-pub enum RevokeProfileError {
+pub enum SSHRevokeError {
     #[error("Failed to spawn revocation command over SSH: {0}")]
-    SSHSpawnRevoke(std::io::Error),
+    SpawnRevokeError(std::io::Error),
+}
 
-    #[error("Error revoking deployment: {0}")]
-    SSHRevoke(std::io::Error),
-    #[error("Revoking over SSH resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
-    SSHRevokeExit(Option<i32>, String),
+impl command::HasCommandError for SSHRevokeError {
+    fn title() -> String {
+        "SSH revoke command".to_string()
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum RevokeProfileError {
+    #[error("{0}")]
+    SSHRevoke(#[from] command::CommandError<SSHRevokeError>),
 
     #[error("Deployment data invalid: {0}")]
     InvalidDeployDataDefs(#[from] DeployDataDefsError),
@@ -579,22 +668,35 @@ pub async fn revoke(
     let mut ssh_revoke_child = ssh_activate_command
         .arg(self_revoke_command)
         .spawn()
-        .map_err(RevokeProfileError::SSHSpawnRevoke)?;
+        .map_err(|err| {
+            RevokeProfileError::SSHRevoke(command::CommandError::OtherError(
+                SSHRevokeError::SpawnRevokeError(err),
+            ))
+        })?;
 
-    if deploy_data.merged_settings.interactive_sudo.unwrap_or(false) {
+    if deploy_data
+        .merged_settings
+        .interactive_sudo
+        .unwrap_or(false)
+    {
         trace!("[revoke] Piping in sudo password");
         handle_sudo_stdin(&mut ssh_revoke_child, deploy_defs)
             .await
-            .map_err(RevokeProfileError::SSHRevoke)?;
+            .map_err(|err| RevokeProfileError::SSHRevoke(command::CommandError::RunError(err)))?;
     }
 
     let result = ssh_revoke_child.wait_with_output().await;
 
     match result {
-        Err(x) => Err(RevokeProfileError::SSHRevoke(x)),
+        Err(x) => Err(RevokeProfileError::SSHRevoke(
+            command::CommandError::RunError(x),
+        )),
         Ok(ref x) => match x.status.code() {
             Some(0) => Ok(()),
-            a => Err(RevokeProfileError::SSHRevokeExit(a,format!("{:?}", ssh_activate_command))),
+            a => Err(RevokeProfileError::SSHRevoke(command::CommandError::Exit(
+                a,
+                format!("{:?}", ssh_activate_command),
+            ))),
         },
     }
 }

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -264,9 +264,9 @@ pub enum ConfirmProfileError {
     #[error("Failed to run confirmation command over SSH (the server should roll back): {0}")]
     SSHConfirm(std::io::Error),
     #[error(
-        "Confirming activation over SSH resulted in a bad exit code (the server should roll back): {0:?}"
+        "Confirming activation over SSH resulted in a bad exit code (the server should roll back): {0:?}. The failed command is provided below:\n{1}"
     )]
-    SSHConfirmExit(Option<i32>),
+    SSHConfirmExit(Option<i32>, String),
 }
 
 pub async fn confirm_profile(
@@ -315,7 +315,7 @@ pub async fn confirm_profile(
 
     match ssh_confirm_exit_status.code() {
         Some(0) => (),
-        a => return Err(ConfirmProfileError::SSHConfirmExit(a)),
+        a => return Err(ConfirmProfileError::SSHConfirmExit(a, format!("{:?}", ssh_confirm_command))),
     };
 
     info!("Deployment confirmed.");
@@ -330,15 +330,15 @@ pub enum DeployProfileError {
 
     #[error("Failed to run activation command over SSH: {0}")]
     SSHActivate(std::io::Error),
-    #[error("Activating over SSH resulted in a bad exit code: {0:?}")]
-    SSHActivateExit(Option<i32>),
+    #[error("Activating over SSH resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
+    SSHActivateExit(Option<i32>, String),
     #[error("Activating over SSH resulted in a bad exit code: {0:?}")]
     SSHActivateTimeout(tokio::sync::oneshot::error::RecvError),
 
     #[error("Failed to run wait command over SSH: {0}")]
     SSHWait(std::io::Error),
-    #[error("Waiting over SSH resulted in a bad exit code: {0:?}")]
-    SSHWaitExit(Option<i32>),
+    #[error("Waiting over SSH resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
+    SSHWaitExit(Option<i32>, String),
 
     #[error("Failed to pipe to child stdin: {0}")]
     SSHActivatePipe(std::io::Error),
@@ -427,7 +427,7 @@ pub async fn deploy_profile(
 
         match ssh_activate_exit_status.code() {
             Some(0) => (),
-            a => return Err(DeployProfileError::SSHActivateExit(a)),
+            a => return Err(DeployProfileError::SSHActivateExit(a, format!("{:?}", ssh_activate_command))),
         };
 
         if dry_activate {
@@ -482,7 +482,7 @@ pub async fn deploy_profile(
                 Err(x) => Some(DeployProfileError::SSHActivate(x)),
                 Ok(ref x) => match x.status.code() {
                     Some(0) => None,
-                    a => Some(DeployProfileError::SSHActivateExit(a)),
+                    a => Some(DeployProfileError::SSHActivateExit(a, format!("{:?}", ssh_activate_command))),
                 },
             };
 
@@ -510,7 +510,7 @@ pub async fn deploy_profile(
                 debug!("Wait command ended");
                 match x.map_err(DeployProfileError::SSHWait)?.code() {
                     Some(0) => (),
-                    a => return Err(DeployProfileError::SSHWaitExit(a)),
+                    a => return Err(DeployProfileError::SSHWaitExit(a, format!("{:?}", ssh_wait_command))),
                 };
             },
             x = recv_activate => {
@@ -540,8 +540,8 @@ pub enum RevokeProfileError {
 
     #[error("Error revoking deployment: {0}")]
     SSHRevoke(std::io::Error),
-    #[error("Revoking over SSH resulted in a bad exit code: {0:?}")]
-    SSHRevokeExit(Option<i32>),
+    #[error("Revoking over SSH resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
+    SSHRevokeExit(Option<i32>, String),
 
     #[error("Deployment data invalid: {0}")]
     InvalidDeployDataDefs(#[from] DeployDataDefsError),
@@ -594,7 +594,7 @@ pub async fn revoke(
         Err(x) => Err(RevokeProfileError::SSHRevoke(x)),
         Ok(ref x) => match x.status.code() {
             Some(0) => Ok(()),
-            a => Err(RevokeProfileError::SSHRevokeExit(a)),
+            a => Err(RevokeProfileError::SSHRevokeExit(a,format!("{:?}", ssh_activate_command))),
         },
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ fn parse_fragment(fragment: &str) -> Result<(Option<String>, Option<String>), Pa
 
     let first_child = match ast.root().node().first_child() {
         Some(x) => x,
-        None => return Ok((None, None))
+        None => return Ok((None, None)),
     };
 
     let mut node_over = false;
@@ -320,7 +320,10 @@ fn test_parse_flake() {
     );
 }
 
-pub fn parse_file<'a>(file: &'a str, attribute: &'a str) -> Result<DeployFlake<'a>, ParseFlakeError> {
+pub fn parse_file<'a>(
+    file: &'a str,
+    attribute: &'a str,
+) -> Result<DeployFlake<'a>, ParseFlakeError> {
     let (node, profile) = parse_fragment(attribute)?;
 
     Ok(DeployFlake {
@@ -415,11 +418,16 @@ impl<'a> DeployData<'a> {
 
     fn get_profile_info(&'a self) -> Result<ProfileInfo, DeployDataDefsError> {
         match self.profile.profile_settings.profile_path {
-            Some(ref profile_path) => Ok(ProfileInfo::ProfilePath { profile_path: profile_path.to_string() }),
+            Some(ref profile_path) => Ok(ProfileInfo::ProfilePath {
+                profile_path: profile_path.to_string(),
+            }),
             None => {
                 let profile_user = self.get_profile_user()?;
-                Ok(ProfileInfo::ProfileUserAndName { profile_user, profile_name: self.profile_name.to_string() })
-            },
+                Ok(ProfileInfo::ProfileUserAndName {
+                    profile_user,
+                    profile_name: self.profile_name.to_string(),
+                })
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,7 @@ pub fn init_logger(
 }
 
 pub mod cli;
+pub mod command;
 pub mod data;
 pub mod deploy;
 pub mod push;
@@ -232,7 +233,7 @@ fn parse_fragment(fragment: &str) -> Result<(Option<String>, Option<String>), Pa
     Ok((node, profile))
 }
 
-pub fn parse_flake(flake: &str) -> Result<DeployFlake, ParseFlakeError> {
+pub fn parse_flake(flake: &str) -> Result<DeployFlake<'_>, ParseFlakeError> {
     let flake_fragment_start = flake.find('#');
     let (repo, maybe_fragment) = match flake_fragment_start {
         Some(s) => (&flake[..s], Some(&flake[s + 1..])),

--- a/src/push.rs
+++ b/src/push.rs
@@ -12,8 +12,8 @@ use tokio::process::Command;
 pub enum PushProfileError {
     #[error("Failed to run Nix show-derivation command: {0}")]
     ShowDerivation(std::io::Error),
-    #[error("Nix show-derivation command resulted in a bad exit code: {0:?}")]
-    ShowDerivationExit(Option<i32>),
+    #[error("Nix show-derivation command resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
+    ShowDerivationExit(Option<i32>, String),
     #[error("Nix show-derivation command output contained an invalid UTF-8 sequence: {0}")]
     ShowDerivationUtf8(std::str::Utf8Error),
     #[error("Failed to parse the output of nix show-derivation: {0}")]
@@ -24,8 +24,8 @@ pub enum PushProfileError {
     ShowDerivationEmpty,
     #[error("Failed to run Nix build command: {0}")]
     Build(std::io::Error),
-    #[error("Nix build command resulted in a bad exit code: {0:?}")]
-    BuildExit(Option<i32>),
+    #[error("Nix build command resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
+    BuildExit(Option<i32>, String),
     #[error(
         "Activation script deploy-rs-activate does not exist in profile.\n\
              Did you forget to use deploy-rs#lib.<...>.activate.<...> on your profile path?"
@@ -36,12 +36,12 @@ pub enum PushProfileError {
     ActivateRsDoesntExist,
     #[error("Failed to run Nix sign command: {0}")]
     Sign(std::io::Error),
-    #[error("Nix sign command resulted in a bad exit code: {0:?}")]
-    SignExit(Option<i32>),
+    #[error("Nix sign command resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
+    SignExit(Option<i32>, String),
     #[error("Failed to run Nix copy command: {0}")]
     Copy(std::io::Error),
-    #[error("Nix copy command resulted in a bad exit code: {0:?}")]
-    CopyExit(Option<i32>),
+    #[error("Nix copy command resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
+    CopyExit(Option<i32>, String),
 
     #[error("Failed to run Nix path-info command: {0}")]
     PathInfo(std::io::Error),
@@ -100,7 +100,7 @@ pub async fn build_profile_locally(data: &PushProfileData<'_>, derivation_name: 
 
     match build_exit_status.code() {
         Some(0) => (),
-        a => return Err(PushProfileError::BuildExit(a)),
+        a => return Err(PushProfileError::BuildExit(a,format!("{:?}", build_command))),
     };
 
     if !Path::new(
@@ -133,19 +133,21 @@ pub async fn build_profile_locally(data: &PushProfileData<'_>, derivation_name: 
             data.deploy_data.profile_name, data.deploy_data.node_name
         );
 
-        let sign_exit_status = Command::new("nix")
+        let mut sign_command = Command::new("nix");
+        sign_command
             .arg("sign-paths")
             .arg("-r")
             .arg("-k")
             .arg(local_key)
-            .arg(&data.deploy_data.profile.profile_settings.path)
+            .arg(&data.deploy_data.profile.profile_settings.path);
+        let sign_exit_status = sign_command
             .status()
             .await
             .map_err(PushProfileError::Sign)?;
 
         match sign_exit_status.code() {
             Some(0) => (),
-            a => return Err(PushProfileError::SignExit(a)),
+            a => return Err(PushProfileError::SignExit(a, format!("{:?}", sign_command))),
         };
     }
     Ok(())
@@ -168,13 +170,16 @@ pub async fn build_profile_remotely(data: &PushProfileData<'_>, derivation_name:
 
 
     // copy the derivation to remote host so it can be built there
-    let copy_command_status = Command::new("nix")
+    let mut copy_command = Command::new("nix");
+    copy_command
         .arg("--experimental-features").arg("nix-command")
         .arg("copy")
         .arg("-s")  // fetch dependencies from substitures, not localhost
         .arg("--to").arg(&store_address)
         .arg("--derivation").arg(derivation_name)
         .env("NIX_SSHOPTS", ssh_opts_str.clone())
+        .stdout(Stdio::null());
+    let copy_command_status = copy_command
         .stdout(Stdio::null())
         .status()
         .await
@@ -182,7 +187,7 @@ pub async fn build_profile_remotely(data: &PushProfileData<'_>, derivation_name:
 
     match copy_command_status.code() {
         Some(0) => (),
-        a => return Err(PushProfileError::CopyExit(a)),
+        a => return Err(PushProfileError::CopyExit(a, format!("{:?}", copy_command))),
     };
 
     let mut build_command = Command::new("nix");
@@ -205,7 +210,7 @@ pub async fn build_profile_remotely(data: &PushProfileData<'_>, derivation_name:
 
     match build_exit_status.code() {
         Some(0) => (),
-        a => return Err(PushProfileError::BuildExit(a)),
+        a => return Err(PushProfileError::BuildExit(a,format!("{:?}", build_command))),
     };
 
 
@@ -219,17 +224,19 @@ pub async fn build_profile(data: PushProfileData<'_>) -> Result<(), PushProfileE
     );
 
     // `nix-store --query --deriver` doesn't work on invalid paths, so we parse output of show-derivation :(
-    let show_derivation_output = Command::new("nix")
+    let mut show_derivation_command = Command::new("nix");
+    show_derivation_command
         .arg("--experimental-features").arg("nix-command")
         .arg("show-derivation")
-        .arg(&data.deploy_data.profile.profile_settings.path)
+        .arg(&data.deploy_data.profile.profile_settings.path);
+    let show_derivation_output = show_derivation_command
         .output()
         .await
         .map_err(PushProfileError::ShowDerivation)?;
 
     match show_derivation_output.status.code() {
         Some(0) => (),
-        a => return Err(PushProfileError::ShowDerivationExit(a)),
+        a => return Err(PushProfileError::ShowDerivationExit(a, format!("{:?}", show_derivation_command))),
     };
 
     let show_derivation_json: serde_json::value::Value = serde_json::from_str(
@@ -336,18 +343,19 @@ pub async fn push_profile(data: PushProfileData<'_>) -> Result<(), PushProfileEr
             None => &data.deploy_data.node.node_settings.hostname,
         };
 
-        let copy_exit_status = copy_command
+        copy_command
             .arg("--to")
             .arg(format!("ssh://{}@{}", data.deploy_defs.ssh_user, hostname))
             .arg(&data.deploy_data.profile.profile_settings.path)
-            .env("NIX_SSHOPTS", ssh_opts_str)
+            .env("NIX_SSHOPTS", ssh_opts_str);
+        let copy_exit_status = copy_command
             .status()
             .await
             .map_err(PushProfileError::Copy)?;
 
         match copy_exit_status.code() {
             Some(0) => (),
-            a => return Err(PushProfileError::CopyExit(a)),
+            a => return Err(PushProfileError::CopyExit(a, format!("{:?}", copy_command))),
         };
     }
 

--- a/src/push.rs
+++ b/src/push.rs
@@ -8,24 +8,74 @@ use std::process::Stdio;
 use thiserror::Error;
 use tokio::process::Command;
 
+use crate::command;
+
+#[derive(Error, Debug)]
+pub enum ShowDerivationError {
+    #[error("Nix show-derivation command output contained an invalid UTF-8 sequence: {0}")]
+    Utf8(std::str::Utf8Error),
+    #[error("Failed to parse the output of nix show-derivation: {0}")]
+    Parse(serde_json::Error),
+    #[error("Nix show derivation output is not an object")]
+    Invalid,
+    #[error("Nix show-derivation output is empty")]
+    Empty,
+}
+
+impl command::HasCommandError for ShowDerivationError {
+    fn title() -> String {
+        "Nix show derivation".to_string()
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum BuildError {}
+
+impl command::HasCommandError for BuildError {
+    fn title() -> String {
+        "Nix build".to_string()
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum SignError {}
+
+impl command::HasCommandError for SignError {
+    fn title() -> String {
+        "Nix sign".to_string()
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum CopyError {}
+
+impl command::HasCommandError for CopyError {
+    fn title() -> String {
+        "Nix copy".to_string()
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum PathInfoError {}
+
+impl command::HasCommandError for PathInfoError {
+    fn title() -> String {
+        "Nix path-info".to_string()
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum PushProfileError {
-    #[error("Failed to run Nix show-derivation command: {0}")]
-    ShowDerivation(std::io::Error),
-    #[error("Nix show-derivation command resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
-    ShowDerivationExit(Option<i32>, String),
-    #[error("Nix show-derivation command output contained an invalid UTF-8 sequence: {0}")]
-    ShowDerivationUtf8(std::str::Utf8Error),
-    #[error("Failed to parse the output of nix show-derivation: {0}")]
-    ShowDerivationParse(serde_json::Error),
-    #[error("Nix show derivation output is not an object")]
-    ShowDerivationInvalid,
-    #[error("Nix show-derivation output is empty")]
-    ShowDerivationEmpty,
-    #[error("Failed to run Nix build command: {0}")]
-    Build(std::io::Error),
-    #[error("Nix build command resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
-    BuildExit(Option<i32>, String),
+    #[error("{0}")]
+    ShowDerivation(#[from] command::CommandError<ShowDerivationError>),
+    #[error("{0}")]
+    Build(#[from] command::CommandError<BuildError>),
+    #[error("{0}")]
+    Sign(#[from] command::CommandError<SignError>),
+    #[error("{0}")]
+    Copy(#[from] command::CommandError<CopyError>),
+    #[error("{0}")]
+    PathInfo(#[from] command::CommandError<PathInfoError>),
     #[error(
         "Activation script deploy-rs-activate does not exist in profile.\n\
              Did you forget to use deploy-rs#lib.<...>.activate.<...> on your profile path?"
@@ -34,17 +84,6 @@ pub enum PushProfileError {
     #[error("Activation script activate-rs does not exist in profile.\n\
              Is there a mismatch in deploy-rs used in the flake you're deploying and deploy-rs command you're running?")]
     ActivateRsDoesntExist,
-    #[error("Failed to run Nix sign command: {0}")]
-    Sign(std::io::Error),
-    #[error("Nix sign command resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
-    SignExit(Option<i32>, String),
-    #[error("Failed to run Nix copy command: {0}")]
-    Copy(std::io::Error),
-    #[error("Nix copy command resulted in a bad exit code: {0:?}. The failed command is provided below:\n{1}")]
-    CopyExit(Option<i32>, String),
-
-    #[error("Failed to run Nix path-info command: {0}")]
-    PathInfo(std::io::Error),
 }
 
 pub struct PushProfileData<'a> {
@@ -58,7 +97,10 @@ pub struct PushProfileData<'a> {
     pub extra_build_args: &'a [String],
 }
 
-pub async fn build_profile_locally(data: &PushProfileData<'_>, derivation_name: &str) -> Result<(), PushProfileError> {
+pub async fn build_profile_locally(
+    data: &PushProfileData<'_>,
+    derivation_name: &str,
+) -> Result<(), PushProfileError> {
     info!(
         "Building profile `{}` for node `{}`",
         data.deploy_data.profile_name, data.deploy_data.node_name
@@ -89,19 +131,15 @@ pub async fn build_profile_locally(data: &PushProfileData<'_>, derivation_name: 
         (false, true) => build_command.arg("--no-link"),
     };
 
-    build_command.args(data.extra_build_args);
-
-    let build_exit_status = build_command
+    build_command
+        .args(data.extra_build_args)
         // Logging should be in stderr, this just stops the store path from printing for no reason
-        .stdout(Stdio::null())
-        .status()
+        .stdout(Stdio::null());
+
+    command::Command::new(build_command)
+        .run()
         .await
         .map_err(PushProfileError::Build)?;
-
-    match build_exit_status.code() {
-        Some(0) => (),
-        a => return Err(PushProfileError::BuildExit(a,format!("{:?}", build_command))),
-    };
 
     if !Path::new(
         format!(
@@ -140,20 +178,18 @@ pub async fn build_profile_locally(data: &PushProfileData<'_>, derivation_name: 
             .arg("-k")
             .arg(local_key)
             .arg(&data.deploy_data.profile.profile_settings.path);
-        let sign_exit_status = sign_command
-            .status()
+        command::Command::new(sign_command)
+            .run()
             .await
             .map_err(PushProfileError::Sign)?;
-
-        match sign_exit_status.code() {
-            Some(0) => (),
-            a => return Err(PushProfileError::SignExit(a, format!("{:?}", sign_command))),
-        };
     }
     Ok(())
 }
 
-pub async fn build_profile_remotely(data: &PushProfileData<'_>, derivation_name: &str) -> Result<(), PushProfileError> {
+pub async fn build_profile_remotely(
+    data: &PushProfileData<'_>,
+    derivation_name: &str,
+) -> Result<(), PushProfileError> {
     info!(
         "Building profile `{}` for node `{}` on remote host",
         data.deploy_data.profile_name, data.deploy_data.node_name
@@ -168,51 +204,45 @@ pub async fn build_profile_remotely(data: &PushProfileData<'_>, derivation_name:
 
     let ssh_opts_str = data.deploy_data.merged_settings.ssh_opts.join(" ");
 
-
     // copy the derivation to remote host so it can be built there
     let mut copy_command = Command::new("nix");
     copy_command
-        .arg("--experimental-features").arg("nix-command")
+        .arg("--experimental-features")
+        .arg("nix-command")
         .arg("copy")
-        .arg("-s")  // fetch dependencies from substitures, not localhost
-        .arg("--to").arg(&store_address)
-        .arg("--derivation").arg(derivation_name)
+        .arg("-s") // fetch dependencies from substitures, not localhost
+        .arg("--to")
+        .arg(&store_address)
+        .arg("--derivation")
+        .arg(derivation_name)
         .env("NIX_SSHOPTS", ssh_opts_str.clone())
         .stdout(Stdio::null());
-    let copy_command_status = copy_command
-        .stdout(Stdio::null())
-        .status()
+    command::Command::new(copy_command)
+        .run()
         .await
         .map_err(PushProfileError::Copy)?;
 
-    match copy_command_status.code() {
-        Some(0) => (),
-        a => return Err(PushProfileError::CopyExit(a, format!("{:?}", copy_command))),
-    };
-
     let mut build_command = Command::new("nix");
     build_command
-        .arg("--experimental-features").arg("nix-command")
-        .arg("build").arg(derivation_name)
-        .arg("--eval-store").arg("auto")
-        .arg("--store").arg(&store_address)
+        .arg("--experimental-features")
+        .arg("nix-command")
+        .arg("build")
+        .arg(derivation_name)
+        .arg("--eval-store")
+        .arg("auto")
+        .arg("--store")
+        .arg(&store_address)
         .args(data.extra_build_args)
-        .env("NIX_SSHOPTS", ssh_opts_str.clone());
+        .env("NIX_SSHOPTS", ssh_opts_str.clone())
+        // Logging should be in stderr, this just stops the store path from printing for no reason
+        .stdout(Stdio::null());
 
     debug!("build command: {:?}", build_command);
 
-    let build_exit_status = build_command
-        // Logging should be in stderr, this just stops the store path from printing for no reason
-        .stdout(Stdio::null())
-        .status()
+    command::Command::new(build_command)
+        .run()
         .await
         .map_err(PushProfileError::Build)?;
-
-    match build_exit_status.code() {
-        Some(0) => (),
-        a => return Err(PushProfileError::BuildExit(a,format!("{:?}", build_command))),
-    };
-
 
     Ok(())
 }
@@ -226,36 +256,54 @@ pub async fn build_profile(data: PushProfileData<'_>) -> Result<(), PushProfileE
     // `nix-store --query --deriver` doesn't work on invalid paths, so we parse output of show-derivation :(
     let mut show_derivation_command = Command::new("nix");
     show_derivation_command
-        .arg("--experimental-features").arg("nix-command")
+        .arg("--experimental-features")
+        .arg("nix-command")
         .arg("show-derivation")
         .arg(&data.deploy_data.profile.profile_settings.path);
-    let show_derivation_output = show_derivation_command
-        .output()
+    let show_derivation_command_str = format!("{:?}", show_derivation_command);
+
+    let show_derivation_output = command::Command::new(show_derivation_command)
+        .run()
         .await
         .map_err(PushProfileError::ShowDerivation)?;
 
     match show_derivation_output.status.code() {
         Some(0) => (),
-        a => return Err(PushProfileError::ShowDerivationExit(a, format!("{:?}", show_derivation_command))),
+        _exit_code => {
+            return Err(PushProfileError::ShowDerivation(
+                command::CommandError::Exit(show_derivation_output, show_derivation_command_str),
+            ))
+        }
     };
 
     let show_derivation_json: serde_json::value::Value = serde_json::from_str(
-        std::str::from_utf8(&show_derivation_output.stdout)
-            .map_err(PushProfileError::ShowDerivationUtf8)?,
+        std::str::from_utf8(&show_derivation_output.stdout).map_err(|err| {
+            PushProfileError::ShowDerivation(command::CommandError::OtherError(
+                ShowDerivationError::Utf8(err),
+            ))
+        })?,
     )
-    .map_err(PushProfileError::ShowDerivationParse)?;
+    .map_err(|err| {
+        PushProfileError::ShowDerivation(command::CommandError::OtherError(
+            ShowDerivationError::Parse(err),
+        ))
+    })?;
 
     // Nix 2.33+ nests derivations under a "derivations" key, so try to get that first
     let derivation_info = show_derivation_json
         .get("derivations")
         .unwrap_or(&show_derivation_json)
         .as_object()
-        .ok_or(PushProfileError::ShowDerivationInvalid)?;
+        .ok_or(PushProfileError::ShowDerivation(
+            command::CommandError::OtherError(ShowDerivationError::Invalid),
+        ))?;
 
     let deriver_key = derivation_info
         .keys()
         .next()
-        .ok_or(PushProfileError::ShowDerivationEmpty)?;
+        .ok_or(PushProfileError::ShowDerivation(
+            command::CommandError::OtherError(ShowDerivationError::Empty),
+        ))?;
 
     // Nix 2.32+ returns relative paths (without /nix/store/ prefix) in show-derivation output
     // Normalize to always use full store paths
@@ -265,7 +313,13 @@ pub async fn build_profile(data: PushProfileData<'_>) -> Result<(), PushProfileE
         format!("/nix/store/{}", deriver_key)
     };
 
-    let new_deriver = if data.supports_flakes || data.deploy_data.merged_settings.remote_build.unwrap_or(false) {
+    let new_deriver = if data.supports_flakes
+        || data
+            .deploy_data
+            .merged_settings
+            .remote_build
+            .unwrap_or(false)
+    {
         // Since nix 2.15.0 'nix build <path>.drv' will build only the .drv file itself, not the
         // derivation outputs, '^out' is used to refer to outputs explicitly
         deriver.clone() + "^out"
@@ -273,14 +327,20 @@ pub async fn build_profile(data: PushProfileData<'_>) -> Result<(), PushProfileE
         deriver.clone()
     };
 
-    let path_info_output = Command::new("nix")
-        .arg("--experimental-features").arg("nix-command")
+    let mut path_info_command = Command::new("nix");
+    path_info_command
+        .arg("--experimental-features")
+        .arg("nix-command")
         .arg("path-info")
-        .arg(&deriver)
-        .output().await
+        .arg(&deriver);
+    let path_info_output = command::Command::new(path_info_command)
+        .run()
+        .await
         .map_err(PushProfileError::PathInfo)?;
 
-    let deriver = if std::str::from_utf8(&path_info_output.stdout).map(|s| s.trim()) == Ok(deriver.as_str()) {
+    let deriver = if std::str::from_utf8(&path_info_output.stdout).map(|s| s.trim())
+        == Ok(deriver.as_str())
+    {
         // In this case we're on 2.15.0 or newer, because 'nix path-info <...>.drv'
         // returns the same '<...>.drv' path.
         // If 'nix path-info <...>.drv' returns a different path, then we're on pre 2.15.0 nix and
@@ -295,7 +355,12 @@ pub async fn build_profile(data: PushProfileData<'_>) -> Result<(), PushProfileE
         // 'error: path '...' is not valid'.
         deriver
     };
-    if data.deploy_data.merged_settings.remote_build.unwrap_or(false) {
+    if data
+        .deploy_data
+        .merged_settings
+        .remote_build
+        .unwrap_or(false)
+    {
         if !data.supports_flakes {
             warn!("remote builds using non-flake nix are experimental");
         }
@@ -321,7 +386,12 @@ pub async fn push_profile(data: PushProfileData<'_>) -> Result<(), PushProfileEr
 
     // remote building guarantees that the resulting derivation is stored on the target system
     // no need to copy after building
-    if !data.deploy_data.merged_settings.remote_build.unwrap_or(false) {
+    if !data
+        .deploy_data
+        .merged_settings
+        .remote_build
+        .unwrap_or(false)
+    {
         info!(
             "Copying profile `{}` to node `{}`",
             data.deploy_data.profile_name, data.deploy_data.node_name
@@ -348,15 +418,10 @@ pub async fn push_profile(data: PushProfileData<'_>) -> Result<(), PushProfileEr
             .arg(format!("ssh://{}@{}", data.deploy_defs.ssh_user, hostname))
             .arg(&data.deploy_data.profile.profile_settings.path)
             .env("NIX_SSHOPTS", ssh_opts_str);
-        let copy_exit_status = copy_command
-            .status()
+        command::Command::new(copy_command)
+            .run()
             .await
             .map_err(PushProfileError::Copy)?;
-
-        match copy_exit_status.code() {
-            Some(0) => (),
-            a => return Err(PushProfileError::CopyExit(a, format!("{:?}", copy_command))),
-        };
     }
 
     Ok(())


### PR DESCRIPTION
This PR displays the command that failed when an error is produced after a command exits with a non-zero code. The output is also cleared a bit. Example:

```
🚀 ℹ️ [deploy] [INFO] Running checks for flake in examples/simple/flake.nix
🚀 ❌ [deploy] [ERROR] Failed to check deployment: Nix checking command resulted in a bad exit code: Some(1). The failed command is provided below:
Command { std: "nix" "flake" "check" "examples/simple/flake.nix", kill_on_drop: false }
The stderr output is provided below:
error: in flake URL 'examples/simple/flake.nix', 'flake.nix' is not a commit hash
```