### PR TITLE
`--file` argument analogous to `nix build` & friends

### DIFF
--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -164,7 +164,7 @@ in {
   };
   # Deployment using a non-flake nix
   non-flake-build = mkTest {
-    name = "local-build";
+    name = "non-flake-build";
     flakes = false;
     deployArgs = "-s .#server";
   };

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -162,4 +162,9 @@ in {
     flakes = false;
     deployArgs = "-s .#server";
   };
+  non-flake-with-flakes = mkTest {
+    name = "non-flake-with-flakes";
+    flakes = true;
+    deployArgs = "--file . --targets server";
+  };
 }

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -134,6 +134,12 @@ in {
     isLocal = false;
     deployArgs = "-s .#server --remote-build -- --offline";
   };
+  non-flake-remote-build = mkTest {
+    name = "non-flake-remote-build";
+    isLocal = false;
+    flakes = false;
+    deployArgs = "-s .#server --remote-build";
+  };
   # Deployment with overridden options
   options-overriding = mkTest {
     name = "options-overriding";

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,6 +30,9 @@ pub struct Opts {
     /// A list of flakes to deploy alternatively
     #[clap(long, group = "deploy")]
     targets: Option<Vec<String>>,
+    /// Treat targets as files instead of flakes
+    #[clap(short, long)]
+    file: Option<String>,
     /// Check signatures when using `nix copy`
     #[clap(short, long)]
     checksigs: bool,
@@ -672,15 +675,28 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
         error!("Cannot use both --dry-activate & --boot!");
     }
 
+    // if opts.file.is_some() && (opts.targets.is_some() || opts.target.is_some()) {
+    //     error!("When using --file, only one target is supported!")
+    // }
+
     let deploys = opts
         .clone()
         .targets
         .unwrap_or_else(|| vec![opts.clone().target.unwrap_or_else(|| ".".to_string())]);
 
-    let deploy_flakes: Vec<DeployFlake> = deploys
+    let deploy_flakes: Vec<DeployFlake> =
+        if let Some(file) = &opts.file {
+            deploys
+                .iter()
+                .map(|f| deploy::parse_file(file.as_str(), f.as_str()))
+                .collect::<Result<Vec<DeployFlake>, ParseFlakeError>>()?
+        }
+    else {
+        deploys
         .iter()
         .map(|f| deploy::parse_flake(f.as_str()))
-        .collect::<Result<Vec<DeployFlake>, ParseFlakeError>>()?;
+          .collect::<Result<Vec<DeployFlake>, ParseFlakeError>>()?
+    };
 
     let cmd_overrides = deploy::CmdOverrides {
         ssh_user: opts.ssh_user,
@@ -700,22 +716,29 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
     };
 
     let supports_flakes = test_flake_support().await.map_err(RunError::FlakeTest)?;
+    let do_not_want_flakes = opts.file.is_some();
 
     if !supports_flakes {
         warn!("A Nix version without flakes support was detected, support for this is work in progress");
     }
 
+    if do_not_want_flakes {
+        warn!("The --file option for deployments without flakes is experimental");
+    }
+
+    let using_flakes = supports_flakes && !do_not_want_flakes;
+
     if !opts.skip_checks {
         for deploy_flake in &deploy_flakes {
-            check_deployment(supports_flakes, deploy_flake.repo, &opts.extra_build_args).await?;
+            check_deployment(using_flakes, deploy_flake.repo, &opts.extra_build_args).await?;
         }
     }
     let result_path = opts.result_path.as_deref();
-    let data = get_deployment_data(supports_flakes, &deploy_flakes, &opts.extra_build_args).await?;
+    let data = get_deployment_data(using_flakes, &deploy_flakes, &opts.extra_build_args).await?;
     run_deploy(
         deploy_flakes,
         data,
-        supports_flakes,
+        using_flakes,
         opts.checksigs,
         opts.interactive,
         &cmd_overrides,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -675,10 +675,6 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
         error!("Cannot use both --dry-activate & --boot!");
     }
 
-    // if opts.file.is_some() && (opts.targets.is_some() || opts.target.is_some()) {
-    //     error!("When using --file, only one target is supported!")
-    // }
-
     let deploys = opts
         .clone()
         .targets

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,54 @@ pub enum ParseFlakeError {
     #[error("Unrecognized node or token encountered")]
     Unrecognized,
 }
+
+fn parse_fragment(fragment: &str) -> Result<(Option<String>, Option<String>), ParseFlakeError> {
+    let mut node: Option<String> = None;
+    let mut profile: Option<String> = None;
+
+    let ast = rnix::parse(fragment);
+
+    let first_child = match ast.root().node().first_child() {
+        Some(x) => x,
+        None => return Ok((None, None))
+    };
+
+    let mut node_over = false;
+
+    for entry in first_child.children_with_tokens() {
+        let x: Option<String> = match (entry.kind(), node_over) {
+            (TOKEN_DOT, false) => {
+                node_over = true;
+                None
+            }
+            (TOKEN_DOT, true) => {
+                return Err(ParseFlakeError::PathTooLong);
+            }
+            (NODE_IDENT, _) => Some(entry.into_node().unwrap().text().to_string()),
+            (TOKEN_IDENT, _) => Some(entry.into_token().unwrap().text().to_string()),
+            (NODE_STRING, _) => {
+                let c = entry
+                    .into_node()
+                    .unwrap()
+                    .children_with_tokens()
+                    .nth(1)
+                    .unwrap();
+
+                Some(c.into_token().unwrap().text().to_string())
+            }
+            _ => return Err(ParseFlakeError::Unrecognized),
+        };
+
+        if !node_over {
+            node = x;
+        } else {
+            profile = x;
+        }
+    }
+
+    Ok((node, profile))
+}
+
 pub fn parse_flake(flake: &str) -> Result<DeployFlake, ParseFlakeError> {
     let flake_fragment_start = flake.find('#');
     let (repo, maybe_fragment) = match flake_fragment_start {
@@ -195,51 +243,7 @@ pub fn parse_flake(flake: &str) -> Result<DeployFlake, ParseFlakeError> {
     let mut profile: Option<String> = None;
 
     if let Some(fragment) = maybe_fragment {
-        let ast = rnix::parse(fragment);
-
-        let first_child = match ast.root().node().first_child() {
-            Some(x) => x,
-            None => {
-                return Ok(DeployFlake {
-                    repo,
-                    node: None,
-                    profile: None,
-                })
-            }
-        };
-
-        let mut node_over = false;
-
-        for entry in first_child.children_with_tokens() {
-            let x: Option<String> = match (entry.kind(), node_over) {
-                (TOKEN_DOT, false) => {
-                    node_over = true;
-                    None
-                }
-                (TOKEN_DOT, true) => {
-                    return Err(ParseFlakeError::PathTooLong);
-                }
-                (NODE_IDENT, _) => Some(entry.into_node().unwrap().text().to_string()),
-                (TOKEN_IDENT, _) => Some(entry.into_token().unwrap().text().to_string()),
-                (NODE_STRING, _) => {
-                    let c = entry
-                        .into_node()
-                        .unwrap()
-                        .children_with_tokens()
-                        .nth(1)
-                        .unwrap();
-
-                    Some(c.into_token().unwrap().text().to_string())
-                }
-                _ => return Err(ParseFlakeError::Unrecognized),
-            };
-
-            if !node_over {
-                node = x;
-            } else {
-                profile = x;
-            }
-        }
+        (node, profile) = parse_fragment(fragment)?;
     }
 
     Ok(DeployFlake {
@@ -316,59 +320,10 @@ fn test_parse_flake() {
 }
 
 pub fn parse_file<'a>(file: &'a str, attribute: &'a str) -> Result<DeployFlake<'a>, ParseFlakeError> {
-    let repo = file; //format!("./{file}");
-
-    let mut node: Option<String> = None;
-    let mut profile: Option<String> = None;
-
-    let ast = rnix::parse(attribute);
-
-    let first_child = match ast.root().node().first_child() {
-        Some(x) => x,
-        None => {
-            return Ok(DeployFlake {
-                repo: &repo,
-                node: None,
-                profile: None,
-            })
-        }
-    };
-
-    let mut node_over = false;
-
-    for entry in first_child.children_with_tokens() {
-        let x: Option<String> = match (entry.kind(), node_over) {
-            (TOKEN_DOT, false) => {
-                node_over = true;
-                None
-            }
-            (TOKEN_DOT, true) => {
-                return Err(ParseFlakeError::PathTooLong);
-            }
-            (NODE_IDENT, _) => Some(entry.into_node().unwrap().text().to_string()),
-            (TOKEN_IDENT, _) => Some(entry.into_token().unwrap().text().to_string()),
-            (NODE_STRING, _) => {
-                let c = entry
-                    .into_node()
-                    .unwrap()
-                    .children_with_tokens()
-                    .nth(1)
-                    .unwrap();
-
-                Some(c.into_token().unwrap().text().to_string())
-            }
-            _ => return Err(ParseFlakeError::Unrecognized),
-        };
-
-        if !node_over {
-            node = x;
-        } else {
-            profile = x;
-        }
-    }
+    let (node, profile) = parse_fragment(attribute)?;
 
     Ok(DeployFlake {
-        repo: &repo,
+        repo: &file,
         node,
         profile,
     })


### PR DESCRIPTION
This adds a `--file` option, which allows using `deploy` in repositories which are not nix flakes. `deploy-rs` already has support for falling back to a non-flake version of its logic in case the `nix` available in `$PATH` doesn't have the flake experimental feature flag enabled. However, that's an "if and only if"-situation: if the nix *is* flakes-enabled, there's no way to use the non-flake version. This works well for setups which use nix flakes, but provides a flake-compat `default.nix` fallback, but prevents use of `deploy-rs` in setups which do not use flakes at all but rely on another source-managing tool such as `niv` or `npins`.

`--file` takes as argument a path, and `--targets` and other options continue to work as expected; remote builds also work assuming a new enough nix on the target host. I've also added tests for local & remote builds (and fixed the name of the `non-flake-build` test; looks like i forgot that when I introduced it in https://github.com/serokell/deploy-rs/pull/272)