### PR TITLE
Fix multiple targets failing to be parsed after a major clap update (fixes #325)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,7 +28,7 @@ pub struct Opts {
     target: Option<String>,
 
     /// A list of flakes to deploy alternatively
-    #[arg(long, group = "deploy")]
+    #[arg(long, group = "deploy", num_args = 1..)]
     targets: Option<Vec<String>>,
     /// Treat targets as files instead of flakes
     #[clap(short, long)]


### PR DESCRIPTION
This fixes #325 by adding a missing argument to the decorator of the targets cli arg.