### PR TITLE
fix targets and build args from clap v4 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Any "extra" arguments will be passed into the Nix calls, so for instance to depl
 You can try out this tool easily with `nix run`:
 - `nix run github:serokell/deploy-rs your-flake`
 
-If you want to deploy multiple flakes or a subset of profiles with one invocation, instead of calling `deploy <flake>` you can issue `deploy --targets <flake> [<flake> ...]` where `<flake>` is supposed to take the same format as discussed before.
+If you want to deploy multiple flakes or a subset of profiles with one invocation, instead of calling `deploy <flake>` you can add `--target` multiple times.  Use shell brace expansion to make this easier: `deploy --target={<flake>,<flake>,...}` where `<flake>` is supposed to take the same format as discussed before. Ex: `--target=.#{host1,host2.system,host3.myuser}`.
 
 Running in this mode, if any of the deploys fails, the deploy will be aborted and all successful deploys rolled back. `--rollback-succeeded false` can be used to override this behavior, otherwise the `auto-rollback` argument takes precedent.
 

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -171,6 +171,6 @@ in {
   non-flake-with-flakes = mkTest {
     name = "non-flake-with-flakes";
     flakes = true;
-    deployArgs = "--file . --targets server";
+    deployArgs = "--file . --target server";
   };
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,7 +24,7 @@ use tokio::process::Command;
 #[command(version = "1.0", author = "Serokell <https://serokell.io/>")]
 pub struct Opts {
     /// A flake to deploy, can be repeated
-    #[arg(long, action = clap::ArgAction::Append)]
+    #[arg(short, long, action = clap::ArgAction::Append)]
     target: Option<Vec<String>>,
     /// Treat targets as files instead of flakes
     #[clap(short, long)]


### PR DESCRIPTION
Disclaimer: this was 'vibe' 🤗 patched with LLM, I know very little of rust.

this fixes usage after the clap v4 update.

it removes `--targets` and allows `--target` to be repeated as is how I understand clap v4 wants to work.  (having both was confusing and redundant anyway)

to easily specify multiple targets utilize shell brace expansion:

`--target=.#{host1.profile1,host2.profile3}` etc...

Everything seems to work for me so far.  YMMV

#325
