### PR TITLE
feat: add `--remote-bin-path` option (#298)

### DIFF
--- a/interface.json
+++ b/interface.json
@@ -38,6 +38,9 @@
                 },
                 "interactiveSudo": {
                     "type": "boolean"
+                },
+                "remoteBinPath": {
+                    "type": "string"
                 }
             }
         },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use std::io::{stdin, stdout, Write};
 
-use clap::{ArgMatches, Parser, FromArgMatches};
+use clap::{ArgMatches, FromArgMatches, Parser};
 
 use crate as deploy;
 
@@ -110,6 +110,9 @@ pub struct Opts {
     /// Prompt for sudo password during activation.
     #[arg(long)]
     interactive_sudo: Option<bool>,
+    /// Path to where the nix-store and nix-env binaries are stored on the remote host
+    #[arg(long)]
+    remote_bin_path: Option<PathBuf>,
 }
 
 /// Returns if the available Nix installation supports flakes
@@ -387,9 +390,9 @@ pub enum RunDeployError {
     #[error("Failed to deploy profile to node {0}: {1}")]
     DeployProfile(String, deploy::deploy::DeployProfileError),
     #[error("Failed to build profile on node {0}: {0}")]
-    BuildProfile(String,  deploy::push::PushProfileError),
+    BuildProfile(String, deploy::push::PushProfileError),
     #[error("Failed to push profile to node {0}: {0}")]
-    PushProfile(String,  deploy::push::PushProfileError),
+    PushProfile(String, deploy::push::PushProfileError),
     #[error("No profile named `{0}` was found")]
     ProfileNotFound(String),
     #[error("No node named `{0}` was found")]
@@ -405,7 +408,7 @@ pub enum RunDeployError {
     #[error("Failed to revoke profile for node {0}: {1}")]
     RevokeProfile(String, deploy::deploy::RevokeProfileError),
     #[error("Deployment to node {0} failed, rolled back to previous generation")]
-    Rollback(String)
+    Rollback(String),
 }
 
 type ToDeploy<'a> = Vec<(
@@ -549,7 +552,11 @@ async fn run_deploy(
 
         let mut deploy_defs = deploy_data.defs()?;
 
-        if deploy_data.merged_settings.interactive_sudo.unwrap_or(false) {
+        if deploy_data
+            .merged_settings
+            .interactive_sudo
+            .unwrap_or(false)
+        {
             warn!("Interactive sudo is enabled! Using a sudo password is less secure than correctly configured SSH keys.\nPlease use keys in production environments.");
 
             if deploy_data.merged_settings.sudo.is_some() {
@@ -561,8 +568,15 @@ async fn run_deploy(
                 deploy_defs.sudo = Some(format!("{} -S -p \"\"", original));
             }
 
-            info!("You will now be prompted for the sudo password for {}.", node.node_settings.hostname);
-            let sudo_password = rpassword::prompt_password(format!("(sudo for {}) Password: ", node.node_settings.hostname)).unwrap_or("".to_string());
+            info!(
+                "You will now be prompted for the sudo password for {}.",
+                node.node_settings.hostname
+            );
+            let sudo_password = rpassword::prompt_password(format!(
+                "(sudo for {}) Password: ",
+                node.node_settings.hostname
+            ))
+            .unwrap_or("".to_string());
 
             deploy_defs.sudo_password = Some(sudo_password);
         }
@@ -593,16 +607,16 @@ async fn run_deploy(
 
     for data in data_iter() {
         let node_name: String = data.deploy_data.node_name.to_string();
-        deploy::push::build_profile(data).await.map_err(|e| {
-            RunDeployError::BuildProfile(node_name, e)
-        })?;
+        deploy::push::build_profile(data)
+            .await
+            .map_err(|e| RunDeployError::BuildProfile(node_name, e))?;
     }
 
     for data in data_iter() {
         let node_name: String = data.deploy_data.node_name.to_string();
-        deploy::push::push_profile(data).await.map_err(|e| {
-            RunDeployError::PushProfile(node_name, e)
-        })?;
+        deploy::push::push_profile(data)
+            .await
+            .map_err(|e| RunDeployError::PushProfile(node_name, e))?;
     }
 
     let mut succeeded: Vec<(&deploy::DeployData, &deploy::DeployDefs)> = vec![];
@@ -612,7 +626,8 @@ async fn run_deploy(
     // Rollbacks adhere to the global seeting to auto_rollback and secondary
     // the profile's configuration
     for (_, deploy_data, deploy_defs) in &parts {
-        if let Err(e) = deploy::deploy::deploy_profile(deploy_data, deploy_defs, dry_activate, boot).await
+        if let Err(e) =
+            deploy::deploy::deploy_profile(deploy_data, deploy_defs, dry_activate, boot).await
         {
             error!("{}", e);
             if dry_activate {
@@ -625,14 +640,19 @@ async fn run_deploy(
                 //  the command line)
                 for (deploy_data, deploy_defs) in &succeeded {
                     if deploy_data.merged_settings.auto_rollback.unwrap_or(true) {
-                        deploy::deploy::revoke(*deploy_data, *deploy_defs).await.map_err(|e| {
-                            RunDeployError::RevokeProfile(deploy_data.node_name.to_string(), e)
-                        })?;
+                        deploy::deploy::revoke(*deploy_data, *deploy_defs)
+                            .await
+                            .map_err(|e| {
+                                RunDeployError::RevokeProfile(deploy_data.node_name.to_string(), e)
+                            })?;
                     }
                 }
                 return Err(RunDeployError::Rollback(deploy_data.node_name.to_string()));
             }
-            return Err(RunDeployError::DeployProfile(deploy_data.node_name.to_string(), e))
+            return Err(RunDeployError::DeployProfile(
+                deploy_data.node_name.to_string(),
+                e,
+            ));
         }
         succeeded.push((deploy_data, deploy_defs))
     }
@@ -683,18 +703,16 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
         .targets
         .unwrap_or_else(|| vec![opts.clone().target.unwrap_or_else(|| ".".to_string())]);
 
-    let deploy_flakes: Vec<DeployFlake> =
-        if let Some(file) = &opts.file {
-            deploys
-                .iter()
-                .map(|f| deploy::parse_file(file.as_str(), f.as_str()))
-                .collect::<Result<Vec<DeployFlake>, ParseFlakeError>>()?
-        }
-    else {
+    let deploy_flakes: Vec<DeployFlake> = if let Some(file) = &opts.file {
         deploys
-        .iter()
-        .map(|f| deploy::parse_flake(f.as_str()))
-          .collect::<Result<Vec<DeployFlake>, ParseFlakeError>>()?
+            .iter()
+            .map(|f| deploy::parse_file(file.as_str(), f.as_str()))
+            .collect::<Result<Vec<DeployFlake>, ParseFlakeError>>()?
+    } else {
+        deploys
+            .iter()
+            .map(|f| deploy::parse_flake(f.as_str()))
+            .collect::<Result<Vec<DeployFlake>, ParseFlakeError>>()?
     };
 
     let cmd_overrides = deploy::CmdOverrides {
@@ -711,7 +729,8 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
         dry_activate: opts.dry_activate,
         remote_build: opts.remote_build,
         sudo: opts.sudo,
-        interactive_sudo: opts.interactive_sudo
+        interactive_sudo: opts.interactive_sudo,
+        remote_bin_path: opts.remote_bin_path,
     };
 
     let supports_flakes = test_flake_support().await.map_err(RunError::FlakeTest)?;

--- a/src/data.rs
+++ b/src/data.rs
@@ -33,10 +33,12 @@ pub struct GenericSettings {
     pub magic_rollback: Option<bool>,
     #[serde(rename(deserialize = "sudo"))]
     pub sudo: Option<String>,
-    #[serde(default,rename(deserialize = "remoteBuild"))]
+    #[serde(default, rename(deserialize = "remoteBuild"))]
     pub remote_build: Option<bool>,
     #[serde(rename(deserialize = "interactiveSudo"))]
     pub interactive_sudo: Option<bool>,
+    #[serde(default, rename(deserialize = "remoteBinPath"))]
+    pub remote_bin_path: Option<PathBuf>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/push.rs
+++ b/src/push.rs
@@ -58,7 +58,10 @@ pub struct PushProfileData<'a> {
     pub extra_build_args: &'a [String],
 }
 
-pub async fn build_profile_locally(data: &PushProfileData<'_>, derivation_name: &str) -> Result<(), PushProfileError> {
+pub async fn build_profile_locally(
+    data: &PushProfileData<'_>,
+    derivation_name: &str,
+) -> Result<(), PushProfileError> {
     info!(
         "Building profile `{}` for node `{}`",
         data.deploy_data.profile_name, data.deploy_data.node_name
@@ -151,7 +154,10 @@ pub async fn build_profile_locally(data: &PushProfileData<'_>, derivation_name: 
     Ok(())
 }
 
-pub async fn build_profile_remotely(data: &PushProfileData<'_>, derivation_name: &str) -> Result<(), PushProfileError> {
+pub async fn build_profile_remotely(
+    data: &PushProfileData<'_>,
+    derivation_name: &str,
+) -> Result<(), PushProfileError> {
     info!(
         "Building profile `{}` for node `{}` on remote host",
         data.deploy_data.profile_name, data.deploy_data.node_name
@@ -162,18 +168,29 @@ pub async fn build_profile_remotely(data: &PushProfileData<'_>, derivation_name:
         Some(ref x) => x,
         None => &data.deploy_data.node.node_settings.hostname,
     };
-    let store_address = format!("ssh-ng://{}@{}", data.deploy_defs.ssh_user, hostname);
+
+    let store_address = match data.deploy_data.merged_settings.remote_bin_path {
+        Some(ref remote_path) => format!(
+            "ssh-ng://{}@{}?remote-program={}",
+            data.deploy_defs.ssh_user,
+            hostname,
+            remote_path.join("nix-store").to_string_lossy()
+        ),
+        None => format!("ssh-ng://{}@{}", data.deploy_defs.ssh_user, hostname),
+    };
 
     let ssh_opts_str = data.deploy_data.merged_settings.ssh_opts.join(" ");
 
-
     // copy the derivation to remote host so it can be built there
     let copy_command_status = Command::new("nix")
-        .arg("--experimental-features").arg("nix-command")
+        .arg("--experimental-features")
+        .arg("nix-command")
         .arg("copy")
-        .arg("-s")  // fetch dependencies from substitures, not localhost
-        .arg("--to").arg(&store_address)
-        .arg("--derivation").arg(derivation_name)
+        .arg("-s") // fetch dependencies from substitures, not localhost
+        .arg("--to")
+        .arg(&store_address)
+        .arg("--derivation")
+        .arg(derivation_name)
         .env("NIX_SSHOPTS", ssh_opts_str.clone())
         .stdout(Stdio::null())
         .status()
@@ -187,10 +204,14 @@ pub async fn build_profile_remotely(data: &PushProfileData<'_>, derivation_name:
 
     let mut build_command = Command::new("nix");
     build_command
-        .arg("--experimental-features").arg("nix-command")
-        .arg("build").arg(derivation_name)
-        .arg("--eval-store").arg("auto")
-        .arg("--store").arg(&store_address)
+        .arg("--experimental-features")
+        .arg("nix-command")
+        .arg("build")
+        .arg(derivation_name)
+        .arg("--eval-store")
+        .arg("auto")
+        .arg("--store")
+        .arg(&store_address)
         .args(data.extra_build_args)
         .env("NIX_SSHOPTS", ssh_opts_str.clone());
 
@@ -207,7 +228,6 @@ pub async fn build_profile_remotely(data: &PushProfileData<'_>, derivation_name:
         Some(0) => (),
         a => return Err(PushProfileError::BuildExit(a)),
     };
-
 
     Ok(())
 }
@@ -267,15 +287,15 @@ pub async fn build_profile(data: PushProfileData<'_>) -> Result<(), PushProfileE
     };
 
     let path_info_output = Command::new("nix")
-        .arg("--experimental-features").arg("nix-command")
+        .arg("--experimental-features")
+        .arg("nix-command")
         .arg("path-info")
         .arg(&deriver)
-        .output().await
+        .output()
+        .await
         .map_err(PushProfileError::PathInfo)?;
 
     let deriver = if std::str::from_utf8(&path_info_output.stdout).map(|s| s.trim()) == Ok(deriver.as_str()) {
-        // In this case we're on 2.15.0 or newer, because 'nix path-info <...>.drv'
-        // returns the same '<...>.drv' path.
         // If 'nix path-info <...>.drv' returns a different path, then we're on pre 2.15.0 nix and
         // derivation build result is already present in the /nix/store.
         new_deriver
@@ -288,7 +308,12 @@ pub async fn build_profile(data: PushProfileData<'_>) -> Result<(), PushProfileE
         // 'error: path '...' is not valid'.
         deriver
     };
-    if data.deploy_data.merged_settings.remote_build.unwrap_or(false) {
+    if data
+        .deploy_data
+        .merged_settings
+        .remote_build
+        .unwrap_or(false)
+    {
         if !data.supports_flakes {
             warn!("remote builds using non-flake nix are experimental");
         }
@@ -314,7 +339,12 @@ pub async fn push_profile(data: PushProfileData<'_>) -> Result<(), PushProfileEr
 
     // remote building guarantees that the resulting derivation is stored on the target system
     // no need to copy after building
-    if !data.deploy_data.merged_settings.remote_build.unwrap_or(false) {
+    if !data
+        .deploy_data
+        .merged_settings
+        .remote_build
+        .unwrap_or(false)
+    {
         info!(
             "Copying profile `{}` to node `{}`",
             data.deploy_data.profile_name, data.deploy_data.node_name
@@ -336,9 +366,19 @@ pub async fn push_profile(data: PushProfileData<'_>) -> Result<(), PushProfileEr
             None => &data.deploy_data.node.node_settings.hostname,
         };
 
+        let store_address = match data.deploy_data.merged_settings.remote_bin_path {
+            Some(ref bin_path) => format!(
+                "ssh://{}@{}?remote-program={}",
+                data.deploy_defs.ssh_user,
+                hostname,
+                bin_path.join("nix-store").to_string_lossy()
+            ),
+            None => format!("ssh://{}@{}", data.deploy_defs.ssh_user, hostname),
+        };
+
         let copy_exit_status = copy_command
             .arg("--to")
-            .arg(format!("ssh://{}@{}", data.deploy_defs.ssh_user, hostname))
+            .arg(store_address)
             .arg(&data.deploy_data.profile.profile_settings.path)
             .env("NIX_SSHOPTS", ssh_opts_str)
             .status()


### PR DESCRIPTION
Fixes #298 


The `--remote-bin-path` option adds a way to specify `nix-*` binaries path on non NixOS systems without a need of modyfing target's sshd config.

- During deployment stage, it appends `?remote_program=<remote-bin-path>/nix-store` to the hostname in places here it is needed 
- Dduring activation stage it adds `PATH` env variable to all `Command::new()` calls

Sorry for unrelated changes due to rustfmt :/