### PR TITLE
Fix targets and extra build args

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,6 +40,7 @@ pub struct Opts {
     #[arg(short, long)]
     interactive: bool,
     /// Extra arguments to be passed to nix build
+    #[arg(last = true)]
     extra_build_args: Vec<String>,
 
     /// Print debug logs to output

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,7 +28,7 @@ pub struct Opts {
     target: Option<String>,
 
     /// A list of flakes to deploy alternatively
-    #[arg(long, group = "deploy")]
+    #[arg(long, group = "deploy", num_args = 1..)]
     targets: Option<Vec<String>>,
     /// Treat targets as files instead of flakes
     #[clap(short, long)]


### PR DESCRIPTION
This fixes #325 by building upon the fix (#327) by @VolodiaPG for build targets, adding a fix for extra build args.

With this, deploying to multiple hosts with build args works again, e.g.

```
../deploy-rs/target/debug/deploy -d --targets .#host1 .#host2 .#host3 --keep-result --skip-checks -- --max-jobs 0
```