### PR TITLE
Add systems input and rename 'utils' input to 'flake-utils'

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,26 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1743014863,
@@ -35,9 +55,9 @@
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "systems": "systems",
-        "utils": "utils"
+        "systems": "systems"
       }
     },
     "systems": {
@@ -52,26 +72,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "inputs": {
-        "systems": [
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -36,6 +36,7 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs",
+        "systems": "systems",
         "utils": "utils"
       }
     },
@@ -56,7 +57,9 @@
     },
     "utils": {
       "inputs": {
-        "systems": "systems"
+        "systems": [
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1731533236,

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,13 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    utils.url = "github:numtide/flake-utils";
+    systems.url = "github:nix-systems/default";
+
+    utils = {
+      url = "github:numtide/flake-utils";
+      inputs.systems.follows = "systems";
+    };
+
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -151,7 +151,7 @@
       };
     };
   } //
-    flake-utils.lib.eachSystem (flake-utils.lib.defaultSystems ++ ["aarch64-darwin"]) (system:
+    flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
           inherit system;

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     systems.url = "github:nix-systems/default";
 
-    utils = {
+    flake-utils = {
       url = "github:numtide/flake-utils";
       inputs.systems.follows = "systems";
     };
@@ -21,7 +21,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, utils, ... }@inputs:
+  outputs = { self, nixpkgs, flake-utils, ... }@inputs:
   {
     overlays.default = final: prev:
     {
@@ -151,7 +151,7 @@
       };
     };
   } //
-    utils.lib.eachSystem (utils.lib.defaultSystems ++ ["aarch64-darwin"]) (system:
+    flake-utils.lib.eachSystem (flake-utils.lib.defaultSystems ++ ["aarch64-darwin"]) (system:
       let
         pkgs = import nixpkgs {
           inherit system;

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -50,11 +50,11 @@ let
     flakeInputs = ''
       deploy-rs.url = "${../..}";
       deploy-rs.inputs.utils.follows = "utils";
+      deploy-rs.inputs.systems.follows = "systems";
       deploy-rs.inputs.flake-compat.follows = "flake-compat";
 
       nixpkgs.url = "${inputs.nixpkgs}";
       utils.url = "${inputs.utils}";
-      utils.inputs.systems.follows = "systems";
       systems.url = "${inputs.utils.inputs.systems}";
       flake-compat.url = "${inputs.flake-compat}";
       flake-compat.flake = false;

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -49,13 +49,13 @@ let
 
     flakeInputs = ''
       deploy-rs.url = "${../..}";
-      deploy-rs.inputs.utils.follows = "utils";
+      deploy-rs.inputs.flake-utils.follows = "flake-utils";
       deploy-rs.inputs.systems.follows = "systems";
       deploy-rs.inputs.flake-compat.follows = "flake-compat";
 
       nixpkgs.url = "${inputs.nixpkgs}";
-      utils.url = "${inputs.utils}";
-      systems.url = "${inputs.utils.inputs.systems}";
+      flake-utils.url = "${inputs.flake-utils}";
+      systems.url = "${inputs.flake-utils.inputs.systems}";
       flake-compat.url = "${inputs.flake-compat}";
       flake-compat.flake = false;
 


### PR DESCRIPTION
```
commit 428b3a54cabd0fd93fa487979e225c43de679785
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-10-16 15:21:47 +0200

    Add systems input to leverage extensible flake systems pattern

    Add the systems input to transitively leverage the "externally
    extensible flake systems" [1] pattern.

    [1]: https://github.com/nix-systems/nix-systems

 flake.lock            | 5 ++++-
 flake.nix             | 8 +++++++-
 nix/tests/default.nix | 2 +-
 3 files changed, 12 insertions(+), 3 deletions(-)

commit 1686c4e1d45be322bdba161cc8bb3468e782107c
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-10-16 15:31:49 +0200

    Conventionally rename 'utils' input to 'flake-utils'

 flake.lock            | 44 ++++++++++++++++++++++----------------------
 flake.nix             |  6 +++---
 nix/tests/default.nix |  6 +++---
 3 files changed, 28 insertions(+), 28 deletions(-)

commit 710f9d7c1a5a47af49a43581c716c657b98967db
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-10-16 19:08:00 +0200

    Remove redundant aarch64-darwin system already present by default

    Remove the explicitly added aarch64-darwin system that is already
    included in the default systems input.

    Maybe this was not the case at the time of commit ed1ee1d86684 ("add
    aarch64-darwin to built systems") from four years ago.

    Reverts: ed1ee1d86684 ("add aarch64-darwin to built systems")

 flake.nix | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

The first two patches are strongly inspired by https://github.com/NotAShelf/nvf/pull/1001, while the last one is merely a cleanup.

I tested this PR with `nix flake check` in this repo and by running `nix flake check` in my NixOS configuration.
