### PR TITLE
use shlex to parse/ escape stings for POSIX shells

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
+ "shlex",
  "signal-hook",
  "thiserror 2.0.12",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ rpassword = "7.3.1"
 unescape = "0.1.0"
 indicatif = { version = "0.17.8", features = ["tokio", "futures"] }
 tokio-stream = { version = "0.1.16", features = ["io-util"] }
+shlex = "1.3.0"
 
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,13 @@ pub fn make_lock_path(temp_path: &Path, closure: &str) -> PathBuf {
     temp_path.join(format!("deploy-rs-canary-{}", lock_hash))
 }
 
+/// Splits `--ssh-opts` like a POSIX shell, so a quoted option isn't broken
+/// apart on its own spaces. Falls back to a plain space split if the
+/// string isn't validly quoted.
+fn parse_ssh_opts(ssh_opts: &str) -> Vec<String> {
+    shlex::split(ssh_opts).unwrap_or(ssh_opts.split(' ').map(|x| x.to_owned()).collect())
+}
+
 const fn make_emoji(level: log::Level) -> &'static str {
     match level {
         log::Level::Error => "❌",
@@ -533,8 +540,7 @@ pub fn make_deploy_data(
         merged_settings.user = cmd_overrides.profile_user.clone();
     }
     if let Some(ref ssh_opts) = cmd_overrides.ssh_opts {
-        merged_settings.ssh_opts =
-            shlex::split(ssh_opts).unwrap_or(ssh_opts.split(' ').map(|x| x.to_owned()).collect());
+        merged_settings.ssh_opts = parse_ssh_opts(ssh_opts);
     }
     if let Some(fast_connection) = cmd_overrides.fast_connection {
         merged_settings.fast_connection = Some(fast_connection);
@@ -565,5 +571,32 @@ pub fn make_deploy_data(
         debug_logs,
         log_dir,
         progressbar: None,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn parse_ssh_opts_keeps_quoted_proxycommand_as_one_token() {
+        // Regression test for #130.
+        let ssh_opts = r#"-o ProxyCommand="wstunnel -L stdio:%h:%p wss://wstunnel.example.com""#;
+        assert_eq!(
+            parse_ssh_opts(ssh_opts),
+            vec![
+                "-o",
+                "ProxyCommand=wstunnel -L stdio:%h:%p wss://wstunnel.example.com",
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_ssh_opts_falls_back_to_space_split_on_bad_quoting() {
+        let ssh_opts = r#"-o ProxyCommand="unterminated"#;
+        assert_eq!(
+            parse_ssh_opts(ssh_opts),
+            vec!["-o", "ProxyCommand=\"unterminated"]
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,7 +533,8 @@ pub fn make_deploy_data(
         merged_settings.user = cmd_overrides.profile_user.clone();
     }
     if let Some(ref ssh_opts) = cmd_overrides.ssh_opts {
-        merged_settings.ssh_opts = ssh_opts.split(' ').map(|x| x.to_owned()).collect();
+        merged_settings.ssh_opts =
+            shlex::split(ssh_opts).unwrap_or(ssh_opts.split(' ').map(|x| x.to_owned()).collect());
     }
     if let Some(fast_connection) = cmd_overrides.fast_connection {
         merged_settings.fast_connection = Some(fast_connection);

--- a/src/push.rs
+++ b/src/push.rs
@@ -486,7 +486,15 @@ pub async fn build_profile_remotely(
     };
     let store_address = format!("ssh-ng://{}@{}", data.deploy_defs.ssh_user, hostname);
 
-    let ssh_opts_str = data.deploy_data.merged_settings.ssh_opts.join(" ");
+    let ssh_opts_str = shlex::try_join(
+        data.deploy_data
+            .merged_settings
+            .ssh_opts
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<&str>>(),
+    )
+    .unwrap_or(data.deploy_data.merged_settings.ssh_opts.join(" "));
 
     // copy the derivation to remote host so it can be built there
     let copy_command_status = {
@@ -769,15 +777,15 @@ fn parse_build_out_path(stdout: &[u8]) -> Result<String, PushProfileError> {
 }
 
 pub async fn push_profile(data: &PushProfileData, closure: &str) -> Result<(), PushProfileError> {
-    let ssh_opts_str = data
-        .deploy_data
-        .merged_settings
-        .ssh_opts
-        // This should provide some extra safety, but it also breaks for some reason, oh well
-        // .iter()
-        // .map(|x| format!("'{}'", x))
-        // .collect::<Vec<String>>()
-        .join(" ");
+    let ssh_opts_str = shlex::try_join(
+        data.deploy_data
+            .merged_settings
+            .ssh_opts
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<&str>>(),
+    )
+    .unwrap_or(data.deploy_data.merged_settings.ssh_opts.join(" "));
 
     // remote building guarantees that the resulting derivation is stored on the target system
     // no need to copy after building

--- a/src/push.rs
+++ b/src/push.rs
@@ -486,15 +486,7 @@ pub async fn build_profile_remotely(
     };
     let store_address = format!("ssh-ng://{}@{}", data.deploy_defs.ssh_user, hostname);
 
-    let ssh_opts_str = shlex::try_join(
-        data.deploy_data
-            .merged_settings
-            .ssh_opts
-            .iter()
-            .map(String::as_str)
-            .collect::<Vec<&str>>(),
-    )
-    .unwrap_or(data.deploy_data.merged_settings.ssh_opts.join(" "));
+    let ssh_opts_str = join_ssh_opts(&data.deploy_data.merged_settings.ssh_opts);
 
     // copy the derivation to remote host so it can be built there
     let copy_command_status = {
@@ -776,16 +768,14 @@ fn parse_build_out_path(stdout: &[u8]) -> Result<String, PushProfileError> {
     Ok(trimmed.to_string())
 }
 
+/// Joins ssh options into the `NIX_SSHOPTS` string, quoting any option
+/// that contains a space so it isn't split apart on Nix's end.
+fn join_ssh_opts(ssh_opts: &[String]) -> String {
+    shlex::try_join(ssh_opts.iter().map(String::as_str)).unwrap_or(ssh_opts.join(" "))
+}
+
 pub async fn push_profile(data: &PushProfileData, closure: &str) -> Result<(), PushProfileError> {
-    let ssh_opts_str = shlex::try_join(
-        data.deploy_data
-            .merged_settings
-            .ssh_opts
-            .iter()
-            .map(String::as_str)
-            .collect::<Vec<&str>>(),
-    )
-    .unwrap_or(data.deploy_data.merged_settings.ssh_opts.join(" "));
+    let ssh_opts_str = join_ssh_opts(&data.deploy_data.merged_settings.ssh_opts);
 
     // remote building guarantees that the resulting derivation is stored on the target system
     // no need to copy after building
@@ -889,5 +879,20 @@ mod test {
         let stdout = b"/nix/store/a\n/nix/store/b\n";
         let err = parse_build_out_path(stdout).expect_err("multiline stdout must error");
         assert!(matches!(err, PushProfileError::BuildStdoutMultiline(_)));
+    }
+
+    #[test]
+    fn join_ssh_opts_round_trips_option_containing_a_space() {
+        // Regression test for #343.
+        let ssh_opts = vec!["-o".to_string(), "ProxyCommand=foo bar".to_string()];
+        let joined = join_ssh_opts(&ssh_opts);
+        assert_eq!(shlex::split(&joined).unwrap(), ssh_opts);
+    }
+
+    #[test]
+    fn join_ssh_opts_round_trips_plain_options() {
+        let ssh_opts = vec!["-o".to_string(), "StrictHostKeyChecking=no".to_string()];
+        let joined = join_ssh_opts(&ssh_opts);
+        assert_eq!(shlex::split(&joined).unwrap(), ssh_opts);
     }
 }


### PR DESCRIPTION
Use the [shlex](https://crates.io/crates/shlex) crate to split/ parse the `ssh_opts` instead of just splitting by `' '`.
If shlex fails to parse/ join, we fall back to the old way.

Fixes #130. Might fix #343. 