### PR TITLE
flake: fix string escapes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,11 +26,11 @@
           version = "0.1.0";
 
           src = final.lib.sourceByRegex ./. [
-            "Cargo\.lock"
-            "Cargo\.toml"
+            "Cargo\\.lock"
+            "Cargo\\.toml"
             "src"
             "src/bin"
-            ".*\.rs$"
+            ".*\\.rs$"
           ];
 
           cargoLock.lockFile = ./Cargo.lock;

--- a/flake.nix
+++ b/flake.nix
@@ -26,13 +26,13 @@
           version = "0.1.0";
 
           src = final.lib.sourceByRegex ./. [
-            "Cargo.lock"
-            "Cargo.toml"
+            "Cargo\\.lock"
+            "Cargo\\.toml"
             "src"
             "src/bin"
-            ".*.rs$"
+            ".*\\.rs$"
             "nix"
-            "nix/.*.nix$"
+            "nix/.*\\.nix$"
           ];
 
           cargoLock.lockFile = ./Cargo.lock;


### PR DESCRIPTION
In nixlang "\\." is escaped to just ".". That is, it does nothing. For there to be a "\\." in the resulting string, two backslashes are needed. Lix on main now emits a warning in such cases. See the example nix repl output:

	nix-repl> :p "Cargo\.lock"
	Cargo.lock

	nix-repl> :p "Cargo\\.lock"
	Cargo\.lock