### PR TITLE
feat: add group-based deployment filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ If you want to deploy multiple flakes or a subset of profiles with one invocatio
 
 Running in this mode, if any of the deploys fails, the deploy will be aborted and all successful deploys rolled back. `--rollback-succeeded false` can be used to override this behavior, otherwise the `auto-rollback` argument takes precedent.
 
+You can also filter which profiles are deployed by group using `deploy --groups <group> [<group> ...]`. A profile is selected if any of the requested groups appears in its merged `groups` set.
+
 If you require a signing key to push closures to your server, specify the path to it in the `LOCAL_KEY` environment variable.
 
 Check out `deploy --help` for CLI flags! Remember to check there before making one-time changes to things like hostnames.
@@ -212,6 +214,10 @@ This is a set of options that can be put in any of the above definitions, with t
 
   # This is an optional list of arguments that will be passed to SSH.
   sshOpts = [ "-p" "2121" ];
+
+  # Optional groups used for filtering deployments.
+  # Can be a string or a list of strings; values from profile > node > deploy are merged as a set (deduplicated).
+  groups = [ "web" "prod" ];
 
   # Fast connection to the node. If this is true, copy the whole closure instead of letting the node substitute.
   # This defaults to `false`

--- a/examples/groups/README.md
+++ b/examples/groups/README.md
@@ -1,0 +1,16 @@
+<!--
+SPDX-FileCopyrightText: 2025 Serokell <https://serokell.io/>
+
+SPDX-License-Identifier: MPL-2.0
+-->
+
+# Example group-based deployment
+
+This example shows how to assign `groups` at deploy, node, and profile levels, then filter
+deployments with `--groups`.
+
+Example usage:
+- Deploy only profiles matching the `web` group:
+  - `nix run github:serokell/deploy-rs -- --groups web`
+- Deploy only profiles matching `blue` or `db`:
+  - `nix run github:serokell/deploy-rs -- --groups blue db`

--- a/examples/groups/flake.nix
+++ b/examples/groups/flake.nix
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 Serokell <https://serokell.io/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+{
+  description = "Deploy two profiles and filter by groups";
+
+  inputs.deploy-rs.url = "github:serokell/deploy-rs";
+
+  outputs = { self, nixpkgs, deploy-rs }: {
+    deploy = {
+      groups = [ "prod" ];
+      nodes.example = {
+        hostname = "localhost";
+        groups = [ "web" "edge" ];
+        profiles = {
+          hello = {
+            groups = "blue";
+            user = "balsoft";
+            path = deploy-rs.lib.x86_64-linux.setActivate nixpkgs.legacyPackages.x86_64-linux.hello "./bin/hello";
+          };
+          cowsay = {
+            groups = [ "green" "db" ];
+            user = "balsoft";
+            path = deploy-rs.lib.x86_64-linux.setActivate nixpkgs.legacyPackages.x86_64-linux.cowsay "./bin/cowsay";
+          };
+        };
+      };
+    };
+
+    checks = builtins.mapAttrs (system: deployLib: deployLib.deployChecks self.deploy) deploy-rs.lib;
+  };
+}

--- a/interface.json
+++ b/interface.json
@@ -18,6 +18,19 @@
                         "type": "string"
                     }
                 },
+                "groups": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
                 "fastConnection": {
                     "type": ["boolean", "null"]
                 },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -79,6 +79,9 @@ pub struct Opts {
     /// Override the SSH options used
     #[arg(long, allow_hyphen_values = true)]
     ssh_opts: Option<String>,
+    /// Filter profiles by group (merged from profile/node/deploy)
+    #[arg(long, num_args = 1..)]
+    groups: Option<Vec<String>>,
     /// Override if the connecting to the target node should be considered fast
     #[arg(long)]
     fast_connection: Option<bool>,
@@ -579,6 +582,17 @@ async fn run_deploy(
             log_dir.clone(),
         );
 
+        if let Some(ref groups) = cmd_overrides.groups {
+            if !deploy_data
+                .merged_settings
+                .groups
+                .iter()
+                .any(|g| groups.contains(g))
+            {
+                continue;
+            }
+        }
+
         let mut deploy_defs = deploy_data.defs()?;
 
         if deploy_data
@@ -615,6 +629,11 @@ async fn run_deploy(
         }
 
         parts.push((deploy_flake, deploy_data, deploy_defs));
+    }
+
+    if parts.is_empty() {
+        info!("No profiles matched selection.");
+        return Ok(());
     }
 
     if interactive {
@@ -906,6 +925,7 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
         ssh_user: opts.ssh_user,
         profile_user: opts.profile_user,
         ssh_opts: opts.ssh_opts,
+        groups: opts.groups,
         fast_connection: opts.fast_connection,
         auto_rollback: opts.auto_rollback,
         hostname: opts.hostname,

--- a/src/data.rs
+++ b/src/data.rs
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use merge::Merge;
+use serde::de::Deserializer;
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
 
 #[derive(Deserialize, Debug, Clone, Merge)]
@@ -37,6 +38,40 @@ pub struct GenericSettings {
     pub remote_build: Option<bool>,
     #[serde(rename(deserialize = "interactiveSudo"))]
     pub interactive_sudo: Option<bool>,
+    #[serde(
+        default,
+        rename(deserialize = "groups"),
+        deserialize_with = "deserialize_groups"
+    )]
+    #[merge(strategy = merge_groups)]
+    pub groups: BTreeSet<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum StringOrVec {
+    String(String),
+    Vec(Vec<String>),
+}
+
+fn deserialize_groups<'de, D>(deserializer: D) -> Result<BTreeSet<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<StringOrVec>::deserialize(deserializer)?;
+    Ok(match value {
+        None => BTreeSet::new(),
+        Some(StringOrVec::String(s)) => {
+            let mut set = BTreeSet::new();
+            set.insert(s);
+            set
+        }
+        Some(StringOrVec::Vec(v)) => v.into_iter().collect(),
+    })
+}
+
+fn merge_groups(left: &mut BTreeSet<String>, right: BTreeSet<String>) {
+    left.extend(right);
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,6 +213,7 @@ pub struct CmdOverrides {
     pub ssh_user: Option<String>,
     pub profile_user: Option<String>,
     pub ssh_opts: Option<String>,
+    pub groups: Option<Vec<String>>,
     pub fast_connection: Option<bool>,
     pub auto_rollback: Option<bool>,
     pub hostname: Option<String>,


### PR DESCRIPTION
## Summary
  Add group-based filtering for deploy targets to allow partial deployments by logical groups.

## Changes
  - Add `groups` generic option (profile/node/deploy) with set-merge semantics.
  - Add CLI flag `--groups <GROUPS>...` and filter deployment selection.
  - Document usage and add an example under `examples/groups`.
  - Example added in `examples/groups`.

## Behavior
  - Effective groups are merged as a set from profile > node > deploy.
  - When `--groups` is provided, only profiles with any overlapping group are selected.
  - Profiles without groups are excluded when filtering is active.


