### PR TITLE
remove unneeded nix string escapes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,11 +26,11 @@
           version = "0.1.0";
 
           src = final.lib.sourceByRegex ./. [
-            "Cargo\.lock"
-            "Cargo\.toml"
+            "Cargo.lock"
+            "Cargo.toml"
             "src"
             "src/bin"
-            ".*\.rs$"
+            ".*.rs$"
           ];
 
           cargoLock.lockFile = ./Cargo.lock;


### PR DESCRIPTION
These do not actually do anything, and are being deprecated in Lix; hence this change is a semantic no-op.

However, it might be that actually escaping the "." inside the regex was intended? (in that case, these should be `\\.`, although given that it seems to have never caused trouble, it's probably not really relevant)