### PR TITLE
Always pass extra nix arguments to nix

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,13 +113,14 @@ pub struct Opts {
 }
 
 /// Returns if the available Nix installation supports flakes
-async fn test_flake_support() -> Result<bool, std::io::Error> {
+async fn test_flake_support(opts: &Opts) -> Result<bool, std::io::Error> {
     debug!("Checking for flake support");
 
     Ok(Command::new("nix")
         .arg("eval")
         .arg("--expr")
         .arg("builtins.getFlake")
+        .args(&opts.extra_build_args)
         // This will error on some machines "intentionally", and we don't really need that printing
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -697,6 +698,9 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
           .collect::<Result<Vec<DeployFlake>, ParseFlakeError>>()?
     };
 
+    let supports_flakes = test_flake_support(&opts).await.map_err(RunError::FlakeTest)?;
+    let do_not_want_flakes = opts.file.is_some();
+
     let cmd_overrides = deploy::CmdOverrides {
         ssh_user: opts.ssh_user,
         profile_user: opts.profile_user,
@@ -713,9 +717,6 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
         sudo: opts.sudo,
         interactive_sudo: opts.interactive_sudo
     };
-
-    let supports_flakes = test_flake_support().await.map_err(RunError::FlakeTest)?;
-    let do_not_want_flakes = opts.file.is_some();
 
     if !supports_flakes {
         warn!("A Nix version without flakes support was detected, support for this is work in progress");

--- a/src/push.rs
+++ b/src/push.rs
@@ -169,7 +169,7 @@ pub async fn build_profile_remotely(data: &PushProfileData<'_>, derivation_name:
 
     // copy the derivation to remote host so it can be built there
     let copy_command_status = Command::new("nix")
-        .arg("--experimental-features").arg("nix-command")
+        .arg("--extra-experimental-features").arg("nix-command")
         .arg("copy")
         .arg("-s")  // fetch dependencies from substitures, not localhost
         .arg("--to").arg(&store_address)
@@ -187,7 +187,7 @@ pub async fn build_profile_remotely(data: &PushProfileData<'_>, derivation_name:
 
     let mut build_command = Command::new("nix");
     build_command
-        .arg("--experimental-features").arg("nix-command")
+        .arg("--extra-experimental-features").arg("nix-command")
         .arg("build").arg(derivation_name)
         .arg("--eval-store").arg("auto")
         .arg("--store").arg(&store_address)
@@ -220,7 +220,7 @@ pub async fn build_profile(data: PushProfileData<'_>) -> Result<(), PushProfileE
 
     // `nix-store --query --deriver` doesn't work on invalid paths, so we parse output of show-derivation :(
     let show_derivation_output = Command::new("nix")
-        .arg("--experimental-features").arg("nix-command")
+        .arg("--extra-experimental-features").arg("nix-command")
         .arg("show-derivation")
         .arg(&data.deploy_data.profile.profile_settings.path)
         .output()
@@ -267,7 +267,7 @@ pub async fn build_profile(data: PushProfileData<'_>) -> Result<(), PushProfileE
     };
 
     let path_info_output = Command::new("nix")
-        .arg("--experimental-features").arg("nix-command")
+        .arg("--extra-experimental-features").arg("nix-command")
         .arg("path-info")
         .arg(&deriver)
         .output().await
@@ -321,6 +321,7 @@ pub async fn push_profile(data: PushProfileData<'_>) -> Result<(), PushProfileEr
         );
 
         let mut copy_command = Command::new("nix");
+        copy_command.arg("--extra-experimental-features").arg("nix-command");
         copy_command.arg("copy");
 
         if data.deploy_data.merged_settings.fast_connection != Some(true) {


### PR DESCRIPTION
Passing extra nix arguments given after the `--` to all nix
invocations (even those that do not do builds) allows using `deploy` for flakes projects, even on
installations where flakes are not enabled globally, by simply passing

~~~
; deploy ... -- --extra-experimental-features flakes
~~~

which did not work before: instead it the `test_flake_support()` check would return `false`, so we'd run the non-flake mode even if explicitly not desired. I'd argue is definitely confusing behaviour; in fact I found it during an introductory Nix session with someone running on a non-flake system, and was myself surprised it did not work.