### PR TITLE
chore: remove ill-defined escapes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,11 +26,11 @@
           version = "0.1.0";
 
           src = final.lib.sourceByRegex ./. [
-            "Cargo\.lock"
-            "Cargo\.toml"
+            "Cargo\\.lock"
+            "Cargo\\.toml"
             "src"
             "src/bin"
-            ".*\.rs$"
+            ".*\\.rs$"
           ];
 
           cargoLock.lockFile = ./Cargo.lock;


### PR DESCRIPTION
Lix was warning about these, not tested with, but should work, with upstream Nix.

In nix, "\." just escapes to "." and is not passed through literally as "\." in double-quoted strings.