### PR TITLE
Implement support for floating output paths

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,8 @@
             "src"
             "src/bin"
             ".*\.rs$"
+            "nix"
+            "nix/.*\.nix$"
           ];
 
           cargoLock.lockFile = ./Cargo.lock;

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -173,4 +173,6 @@ in {
     flakes = true;
     deployArgs = "--file . --targets server";
   };
+  # Pure-evaluation test for the drvPath auto-extraction. Runs without a VM.
+  transform-deploy = import ./transform-deploy.nix { inherit pkgs; };
 }

--- a/nix/tests/transform-deploy.nix
+++ b/nix/tests/transform-deploy.nix
@@ -1,0 +1,55 @@
+# Pure-evaluation test for `../transform-deploy.nix`. The test runs without a
+# VM and without building anything beyond a trivial `runCommand`, so it is
+# cheap enough to run on every `nix flake check`.
+#
+# Asserts:
+#   - a derivation-typed `path` is rewritten to `{ path = outPath; drvPath = drvPath; }`.
+#   - other profile attrs are preserved.
+#   - top-level deploy attrs are preserved.
+#   - a hand-written string-typed `path` passes through unchanged.
+
+{ pkgs }:
+let
+  transformDeploy = import ../transform-deploy.nix;
+
+  # A real, cheap derivation to stand in for what `activate.nixos cfg` returns.
+  fakeProfile = pkgs.runCommand "fake-deploy-rs-profile" { } "touch $out";
+
+  derivationDeploy = {
+    sshUser = "deployer";
+    nodes.demo = {
+      hostname = "demo.example";
+      profiles.system = {
+        path = fakeProfile;
+        sshUser = "root";
+      };
+    };
+  };
+
+  stringDeploy = {
+    nodes.demo = {
+      hostname = "demo.example";
+      profiles.system = {
+        path = "/nix/store/0000000000000000000000000000000000-handwritten";
+      };
+    };
+  };
+
+  drvOut = transformDeploy derivationDeploy;
+  strOut = transformDeploy stringDeploy;
+
+  drvProfile = drvOut.nodes.demo.profiles.system;
+  strProfile = strOut.nodes.demo.profiles.system;
+in
+# A derivation-typed path is split into outPath and drvPath.
+assert drvProfile.path == fakeProfile.outPath;
+assert drvProfile.drvPath == fakeProfile.drvPath;
+# Sibling attrs are preserved.
+assert drvProfile.sshUser == "root";
+assert drvOut.sshUser == "deployer";
+assert drvOut.nodes.demo.hostname == "demo.example";
+# A string-typed path is left untouched, and no drvPath is synthesised.
+assert strProfile.path == "/nix/store/0000000000000000000000000000000000-handwritten";
+assert !(strProfile ? drvPath);
+
+pkgs.runCommand "transform-deploy-test" { } "touch $out"

--- a/nix/tests/transform-deploy.nix
+++ b/nix/tests/transform-deploy.nix
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Serokell <https://serokell.io/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
 # Pure-evaluation test for `../transform-deploy.nix`. The test runs without a
 # VM and without building anything beyond a trivial `runCommand`, so it is
 # cheap enough to run on every `nix flake check`.

--- a/nix/transform-deploy.nix
+++ b/nix/transform-deploy.nix
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Serokell <https://serokell.io/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
 # Returns a transformed copy of `deploy` where any profile whose `path`
 # evaluated to a derivation also exposes that derivation's `drvPath`. This
 # lets deploy-rs build content-addressed and floating-output derivations,

--- a/nix/transform-deploy.nix
+++ b/nix/transform-deploy.nix
@@ -1,0 +1,22 @@
+# Returns a transformed copy of `deploy` where any profile whose `path`
+# evaluated to a derivation also exposes that derivation's `drvPath`. This
+# lets deploy-rs build content-addressed and floating-output derivations,
+# whose `outPath` is only a placeholder at eval time, without users having
+# to set `drvPath` manually in their flake.
+#
+# The deploy-rs binary loads this file via `include_str!` from `src/cli.rs`
+# and applies it. The expression is self-contained so it can be parsed in
+# isolation for linting, and exercised by `nix/tests/transform-deploy.nix`.
+deploy:
+let
+  patchProfile = p:
+    if (p ? path) && (builtins.isAttrs p.path) && (p.path ? drvPath)
+    then p // { path = p.path.outPath; drvPath = p.path.drvPath; }
+    else p;
+  patchNode = n: n // {
+    profiles = builtins.mapAttrs (_: patchProfile) (n.profiles or { });
+  };
+in
+if deploy ? nodes
+then deploy // { nodes = builtins.mapAttrs (_: patchNode) deploy.nodes; }
+else deploy

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -463,6 +463,14 @@ type ToDeploy<'a> = Vec<(
     (&'a str, &'a deploy::data::Profile),
 )>;
 
+// (node_name, profile_name, closure) for a profile that finished building.
+type BuiltProfile = (String, String, String);
+// Per-host build results from the async remote-build pipeline: one Vec of
+// BuiltProfile per host (built in order), or an error if that host's build failed.
+type RemoteBuildResults = Vec<Result<Vec<BuiltProfile>, RunDeployError>>;
+// Per-profile build+push results from the async local-build pipeline.
+type LocalBuildResults = Vec<Result<BuiltProfile, RunDeployError>>;
+
 fn separator(_state: &ProgressState, w: &mut dyn std::fmt::Write) {
     let _ = write!(w, "│");
 }
@@ -730,10 +738,7 @@ async fn run_deploy(
     // push, activate, confirm, and revoke. The async pipeline below reorders
     // and regroups profiles by host, so closures are keyed by (node, profile)
     // instead of threaded through a parallel Vec.
-    let (remote_results, local_results): (
-        Vec<Result<Vec<(String, String, String)>, RunDeployError>>,
-        Vec<Result<(String, String, String), RunDeployError>>,
-    ) = join!(
+    let (remote_results, local_results): (RemoteBuildResults, LocalBuildResults) = join!(
         // remote builds can be run asynchronously
         async move {
             let mut set = JoinSet::new();
@@ -774,7 +779,8 @@ async fn run_deploy(
                         match deploy::push::build_profile(&profile).await {
                             Ok(closure) => built.push((nodename, profilename, closure)),
                             Err(e) => {
-                                result = Err(RunDeployError::BuildProfile(profilename, nodename, e));
+                                result =
+                                    Err(RunDeployError::BuildProfile(profilename, nodename, e));
                                 break;
                             }
                         }
@@ -841,9 +847,16 @@ async fn run_deploy(
                                     profile_name, node_name
                                 ));
                             }
-                            let res = deploy::push::push_profile(&data, &closure).await.map_err(|e| {
-                                RunDeployError::PushProfile(profile_name.clone(), node_name.clone(), e)
-                            });
+                            let res =
+                                deploy::push::push_profile(&data, &closure)
+                                    .await
+                                    .map_err(|e| {
+                                        RunDeployError::PushProfile(
+                                            profile_name.clone(),
+                                            node_name.clone(),
+                                            e,
+                                        )
+                                    });
                             if let Some(pb) = &pb {
                                 match &res {
                                     Ok(()) => {
@@ -895,10 +908,20 @@ async fn run_deploy(
     let mut succeeded: Vec<(&deploy::DeployData, &deploy::DeployDefs, &str)> = vec![];
     for (_, deploy_data, deploy_defs) in &parts {
         let closure = closures
-            .get(&(deploy_data.node_name.clone(), deploy_data.profile_name.clone()))
+            .get(&(
+                deploy_data.node_name.clone(),
+                deploy_data.profile_name.clone(),
+            ))
             .expect("every profile should have a build closure recorded");
-        if let Err(e) =
-            deploy::deploy::deploy_profile(deploy_data, deploy_defs, closure, dry_activate, boot, test).await
+        if let Err(e) = deploy::deploy::deploy_profile(
+            deploy_data,
+            deploy_defs,
+            closure,
+            dry_activate,
+            boot,
+            test,
+        )
+        .await
         {
             error!("{}", e);
             if dry_activate {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -221,6 +221,13 @@ async fn get_deployment_data(
         Command::new("nix-instantiate")
     };
 
+    // Auto-extracts `drvPath` for profiles whose `path` is a derivation, so the
+    // binary can resolve content-addressed and floating-output derivations
+    // whose eval-time `outPath` is a placeholder. The Nix file is a
+    // self-contained function from `deploy` to `deploy`; see
+    // `nix/transform-deploy.nix`.
+    let patch_deploy = include_str!("../nix/transform-deploy.nix");
+
     if supports_flakes {
         eval_command
             .arg("eval")
@@ -234,7 +241,8 @@ async fn get_deployment_data(
                 eval_command.arg(format!(
                     r#"
                       deploy:
-                      (deploy // {{
+                      let patchDeploy = ({2}); in
+                      patchDeploy (deploy // {{
                         nodes = {{
                           "{0}" = deploy.nodes."{0}" // {{
                             profiles = {{
@@ -244,7 +252,7 @@ async fn get_deployment_data(
                         }};
                       }})
                      "#,
-                    node, profile
+                    node, profile, patch_deploy
                 ))
             }
             (Some(node), None) => {
@@ -252,18 +260,19 @@ async fn get_deployment_data(
                 eval_command.arg(format!(
                     r#"
                       deploy:
-                      (deploy // {{
+                      let patchDeploy = ({1}); in
+                      patchDeploy (deploy // {{
                         nodes = {{
-                          inherit (deploy.nodes) "{}";
+                          inherit (deploy.nodes) "{0}";
                         }};
                       }})
                     "#,
-                    node
+                    node, patch_deploy
                 ))
             }
             (None, None) => {
                 // We need to evaluate all profiles of all nodes anyway, so just do it strictly
-                eval_command.arg("deploy: deploy")
+                eval_command.arg(format!("deploy: ({}) deploy", patch_deploy))
             }
             (None, Some(_)) => return Err(GetDeploymentDataError::ProfileNoNode),
         }
@@ -274,7 +283,10 @@ async fn get_deployment_data(
             .arg("--json")
             .arg("--eval")
             .arg("-E")
-            .arg(format!("let r = import {}/.; in if builtins.isFunction r then (r {{}}).deploy else r.deploy", flake.repo))
+            .arg(format!(
+                "({1}) (let r = import {0}/.; in if builtins.isFunction r then (r {{}}).deploy else r.deploy)",
+                flake.repo, patch_deploy
+            ))
     };
 
     eval_command.args(extra_build_args).stdout(Stdio::piped());
@@ -323,6 +335,14 @@ fn print_deployment(
     let mut part_map: HashMap<String, HashMap<String, PromptPart>> = HashMap::new();
 
     for (_, data, defs) in parts {
+        let settings = &data.profile.profile_settings;
+        // Pre-build, a floating-output profile's `path` is just an opaque
+        // placeholder. Show the `.drv` instead so the preview is meaningful.
+        let displayed_path: &str = if settings.path.starts_with("/nix/store/") {
+            &settings.path
+        } else {
+            settings.drv_path.as_deref().unwrap_or(&settings.path)
+        };
         part_map
             .entry(data.node_name.to_string())
             .or_default()
@@ -331,7 +351,7 @@ fn print_deployment(
                 PromptPart {
                     user: &defs.profile_user,
                     ssh_user: &defs.ssh_user,
-                    path: &data.profile.profile_settings.path,
+                    path: displayed_path,
                     hostname: &data.node.node_settings.hostname,
                     ssh_opts: &data.merged_settings.ssh_opts,
                 },
@@ -705,7 +725,15 @@ async fn run_deploy(
     };
     let new_spinner = || ProgressBar::new_spinner().with_style(spinner_style.clone());
 
-    let (remote_results, local_results) = join!(
+    // Build (and, for local profiles, push) phase. Each profile's build yields
+    // its realised /nix/store/... path, which every subsequent step needs:
+    // push, activate, confirm, and revoke. The async pipeline below reorders
+    // and regroups profiles by host, so closures are keyed by (node, profile)
+    // instead of threaded through a parallel Vec.
+    let (remote_results, local_results): (
+        Vec<Result<Vec<(String, String, String)>, RunDeployError>>,
+        Vec<Result<(String, String, String), RunDeployError>>,
+    ) = join!(
         // remote builds can be run asynchronously
         async move {
             let mut set = JoinSet::new();
@@ -722,7 +750,8 @@ async fn run_deploy(
                 };
 
                 set.spawn(async move {
-                    let mut res = Ok(());
+                    let mut built = Vec::new();
+                    let mut result = Ok(());
 
                     // build profile in order, one after the other
                     for mut profile in profiles {
@@ -742,32 +771,29 @@ async fn run_deploy(
                             profilename, nodename
                         );
 
-                        res = deploy::push::build_profile(&profile).await.map_err(|e| {
-                            RunDeployError::BuildProfile(
-                                profilename.to_string(),
-                                nodename.to_string(),
-                                e,
-                            )
-                        });
-                        if res.is_err() {
-                            break;
+                        match deploy::push::build_profile(&profile).await {
+                            Ok(closure) => built.push((nodename, profilename, closure)),
+                            Err(e) => {
+                                result = Err(RunDeployError::BuildProfile(profilename, nodename, e));
+                                break;
+                            }
                         }
                     }
 
                     if let Some(pb) = &pb {
-                        match res {
+                        match &result {
                             Ok(()) => {
                                 pb.set_style(finish_style());
                                 pb.finish_with_message("Done!");
                             }
-                            Err(ref e) => {
+                            Err(e) => {
                                 pb.set_style(finish_style_error());
                                 pb.finish_with_message(format!("Error: {}", e));
                             }
                         }
                     }
 
-                    res
+                    result.map(|()| built)
                 });
             }
 
@@ -801,12 +827,12 @@ async fn run_deploy(
                     None
                 };
 
-                let res = deploy::push::build_profile(&data).await.map_err(|e| {
+                let build_result = deploy::push::build_profile(&data).await.map_err(|e| {
                     RunDeployError::BuildProfile(profile_name.clone(), node_name.clone(), e)
                 });
 
-                match res {
-                    Ok(()) => {
+                match build_result {
+                    Ok(closure) => {
                         set.spawn(async move {
                             let data = data.clone();
                             if let Some(pb) = &pb {
@@ -815,25 +841,25 @@ async fn run_deploy(
                                     profile_name, node_name
                                 ));
                             }
-                            let res = deploy::push::push_profile(&data).await.map_err(|e| {
-                                RunDeployError::PushProfile(profile_name, node_name, e)
+                            let res = deploy::push::push_profile(&data, &closure).await.map_err(|e| {
+                                RunDeployError::PushProfile(profile_name.clone(), node_name.clone(), e)
                             });
                             if let Some(pb) = &pb {
-                                match res {
+                                match &res {
                                     Ok(()) => {
                                         pb.set_style(finish_style());
                                         pb.finish_with_message("Done!");
                                     }
-                                    Err(ref e) => {
+                                    Err(e) => {
                                         pb.set_style(finish_style_error());
                                         pb.finish_with_message(format!("Error: {}", e));
                                     }
                                 }
                             }
-                            res
+                            res.map(|()| (node_name, profile_name, closure))
                         });
                     }
-                    Err(ref e) => {
+                    Err(e) => {
                         if let Some(pb) = &pb {
                             pb.set_style(finish_style_error());
                             pb.finish_with_message(format!("Error: {}", e));
@@ -841,7 +867,7 @@ async fn run_deploy(
                         // "spawn" a future that just returns the error when building locally fails
                         // this will ensure that the deployment is actually aborted in the error
                         // handling code below
-                        set.spawn(async move { res });
+                        set.spawn(async move { Err(e) });
                     }
                 }
             }
@@ -849,22 +875,30 @@ async fn run_deploy(
         }
     );
 
-    // abort here if any build + push or push + build failed
+    // abort here if any build + push or push + build failed, and collect the
+    // realised closure for every profile that made it through
+    let mut closures: HashMap<(String, String), String> = HashMap::new();
     for result in remote_results {
-        result?
+        for (node_name, profile_name, closure) in result? {
+            closures.insert((node_name, profile_name), closure);
+        }
     }
     for result in local_results {
-        result?
+        let (node_name, profile_name, closure) = result?;
+        closures.insert((node_name, profile_name), closure);
     }
 
     // Run all activations
     // In case of an error, rollback any previoulsy made deployment.
     // Rollbacks adhere to the global seeting to auto_rollback and secondary
     // the profile's configuration
-    let mut succeeded: Vec<(&deploy::DeployData, &deploy::DeployDefs)> = vec![];
+    let mut succeeded: Vec<(&deploy::DeployData, &deploy::DeployDefs, &str)> = vec![];
     for (_, deploy_data, deploy_defs) in &parts {
+        let closure = closures
+            .get(&(deploy_data.node_name.clone(), deploy_data.profile_name.clone()))
+            .expect("every profile should have a build closure recorded");
         if let Err(e) =
-            deploy::deploy::deploy_profile(deploy_data, deploy_defs, dry_activate, boot, test).await
+            deploy::deploy::deploy_profile(deploy_data, deploy_defs, closure, dry_activate, boot, test).await
         {
             error!("{}", e);
             if dry_activate {
@@ -875,9 +909,9 @@ async fn run_deploy(
                 // revoking all previous deploys
                 // (adheres to profile configuration if not set explicitely by
                 //  the command line)
-                for (deploy_data, deploy_defs) in &succeeded {
+                for (deploy_data, deploy_defs, prev_closure) in &succeeded {
                     if deploy_data.merged_settings.auto_rollback.unwrap_or(true) {
-                        deploy::deploy::revoke(deploy_data, deploy_defs)
+                        deploy::deploy::revoke(deploy_data, deploy_defs, prev_closure)
                             .await
                             .map_err(|e| {
                                 RunDeployError::RevokeProfile(
@@ -896,7 +930,7 @@ async fn run_deploy(
                 e,
             ));
         }
-        succeeded.push((deploy_data, deploy_defs))
+        succeeded.push((deploy_data, deploy_defs, closure.as_str()))
     }
 
     Ok(())

--- a/src/data.rs
+++ b/src/data.rs
@@ -91,6 +91,14 @@ pub struct ProfileSettings {
     pub path: String,
     #[serde(rename(deserialize = "profilePath"))]
     pub profile_path: Option<String>,
+    /// `.drv` path of the derivation that produces `path`. Populated by the
+    /// internal eval transformation in `nix/transform-deploy.nix` so the binary
+    /// knows which derivation to build when `path` is only a placeholder, as
+    /// happens for content-addressed and floating-output derivations. The field
+    /// is deliberately omitted from `interface.json` and kept `pub(crate)`; it
+    /// is wire-format plumbing, not a user setting.
+    #[serde(rename(deserialize = "drvPath"))]
+    pub(crate) drv_path: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -295,6 +295,7 @@ pub async fn confirm_profile(
     deploy_defs: &super::DeployDefs,
     temp_path: &Path,
     ssh_addr: &str,
+    closure: &str,
 ) -> Result<(), ConfirmProfileError> {
     let mut ssh_confirm_command = Command::new("ssh");
     ssh_confirm_command
@@ -305,7 +306,7 @@ pub async fn confirm_profile(
         ssh_confirm_command.arg(ssh_opt);
     }
 
-    let lock_path = super::make_lock_path(temp_path, &deploy_data.profile.profile_settings.path);
+    let lock_path = super::make_lock_path(temp_path, closure);
 
     let mut confirm_command = format!("rm {}", lock_path.display());
     if let Some(sudo_cmd) = &deploy_defs.sudo {
@@ -397,6 +398,7 @@ pub enum DeployProfileError {
 pub async fn deploy_profile(
     deploy_data: &super::DeployData,
     deploy_defs: &super::DeployDefs,
+    closure: &str,
     dry_activate: bool,
     boot: bool,
     test: bool,
@@ -424,7 +426,7 @@ pub async fn deploy_profile(
     let self_activate_command = build_activate_command(&ActivateCommandData {
         sudo: &deploy_defs.sudo,
         profile_info: &deploy_data.get_profile_info()?,
-        closure: &deploy_data.profile.profile_settings.path,
+        closure,
         auto_rollback,
         temp_path,
         confirm_timeout,
@@ -506,7 +508,7 @@ pub async fn deploy_profile(
     } else {
         let self_wait_command = build_wait_command(&WaitCommandData {
             sudo: &deploy_defs.sudo,
-            closure: &deploy_data.profile.profile_settings.path,
+            closure,
             temp_path,
             activation_timeout,
             debug_logs: deploy_data.debug_logs,
@@ -625,7 +627,7 @@ pub async fn deploy_profile(
 
         info!("Success activating, attempting to confirm activation");
 
-        let c = confirm_profile(deploy_data, deploy_defs, temp_path, &ssh_addr).await;
+        let c = confirm_profile(deploy_data, deploy_defs, temp_path, &ssh_addr, closure).await;
         recv_activated.await.map_err(|x| {
             DeployProfileError::SSHActivate(command::CommandError::OtherError(
                 SSHActivateError::Timeout(x),
@@ -664,10 +666,11 @@ pub enum RevokeProfileError {
 pub async fn revoke(
     deploy_data: &crate::DeployData,
     deploy_defs: &crate::DeployDefs,
+    closure: &str,
 ) -> Result<(), RevokeProfileError> {
     let self_revoke_command = build_revoke_command(&RevokeCommandData {
         sudo: &deploy_defs.sudo,
-        closure: &deploy_data.profile.profile_settings.path,
+        closure,
         profile_info: deploy_data.get_profile_info()?,
         debug_logs: deploy_data.debug_logs,
         log_dir: deploy_data.log_dir.as_deref(),

--- a/src/push.rs
+++ b/src/push.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+use crate::data::ProfileSettings;
 use indicatif::ProgressBar;
 use log::{debug, info, warn};
 use std::collections::HashMap;
@@ -97,6 +98,8 @@ pub enum PushProfileError {
              Is there a mismatch in deploy-rs used in the flake you're deploying and deploy-rs command you're running?"
     )]
     ActivateRsDoesntExist,
+    #[error("Failed to resolve floating-output store path via `nix path-info`: {0}")]
+    ResolveClosure(String),
 }
 
 #[derive(Clone)]
@@ -114,7 +117,7 @@ pub struct PushProfileData {
 pub async fn build_profile_locally(
     data: &PushProfileData,
     derivation_name: &str,
-) -> Result<(), PushProfileError> {
+) -> Result<String, PushProfileError> {
     info!(
         "Building profile `{}` for node `{}`",
         data.deploy_data.profile_name, data.deploy_data.node_name
@@ -186,27 +189,13 @@ pub async fn build_profile_locally(
         a => return Err(PushProfileError::BuildExit(a)),
     };
 
-    if !Path::new(
-        format!(
-            "{}/deploy-rs-activate",
-            data.deploy_data.profile.profile_settings.path
-        )
-        .as_str(),
-    )
-    .exists()
-    {
+    let closure = resolve_closure(&data.deploy_data.profile.profile_settings, None, None).await?;
+
+    if !Path::new(format!("{}/deploy-rs-activate", closure).as_str()).exists() {
         return Err(PushProfileError::DeployRsActivateDoesntExist);
     }
 
-    if !Path::new(
-        format!(
-            "{}/activate-rs",
-            data.deploy_data.profile.profile_settings.path
-        )
-        .as_str(),
-    )
-    .exists()
-    {
+    if !Path::new(format!("{}/activate-rs", closure).as_str()).exists() {
         return Err(PushProfileError::ActivateRsDoesntExist);
     }
 
@@ -222,13 +211,13 @@ pub async fn build_profile_locally(
             .arg("-r")
             .arg("-k")
             .arg(local_key)
-            .arg(&data.deploy_data.profile.profile_settings.path);
+            .arg(&closure);
         command::Command::new(sign_command)
             .status()
             .await
             .map_err(PushProfileError::Sign)?;
     }
-    Ok(())
+    Ok(closure)
 }
 
 // Nix `internal-json` activity types (see nix's `logging.hh`).
@@ -449,7 +438,7 @@ async fn update_pb_with_child_output(pb: &ProgressBar, child: &mut Child) {
 pub async fn build_profile_remotely(
     data: &PushProfileData,
     derivation_name: &str,
-) -> Result<(), PushProfileError> {
+) -> Result<String, PushProfileError> {
     info!(
         "Building profile `{}` for node `{}` on remote host",
         data.deploy_data.profile_name, data.deploy_data.node_name
@@ -550,88 +539,114 @@ pub async fn build_profile_remotely(
         a => return Err(PushProfileError::BuildExit(a)),
     };
 
-    Ok(())
+    // The realised output lives on the remote store, so resolve it over ssh-ng.
+    resolve_closure(&data.deploy_data.profile.profile_settings, Some(&store_address), Some(&ssh_opts_str)).await
 }
 
-pub async fn build_profile(data: &PushProfileData) -> Result<(), PushProfileError> {
-    debug!(
-        "Finding the deriver of store path for {}",
-        &data.deploy_data.profile.profile_settings.path
-    );
+pub async fn build_profile(data: &PushProfileData) -> Result<String, PushProfileError> {
+    let profile_settings = &data.deploy_data.profile.profile_settings;
 
-    // `nix-store --query --deriver` doesn't work on invalid paths, so we parse output of show-derivation :(
-    let mut show_derivation_command = Command::new("nix");
-    show_derivation_command
-        .arg("--experimental-features")
-        .arg("nix-command")
-        .arg("show-derivation")
-        .arg(&data.deploy_data.profile.profile_settings.path);
-    let show_derivation_command_str = format!("{:?}", show_derivation_command);
+    let supports_caret = data.supports_flakes || data.deploy_data.merged_settings.remote_build.unwrap_or(false);
 
-    let show_derivation_output = command::Command::new(show_derivation_command)
-        .run()
-        .await
-        .map_err(PushProfileError::ShowDerivation)?;
+    // The eval transformation in `nix/transform-deploy.nix` attaches `drvPath`
+    // to every derivation-typed profile path, so this branch is hit whenever
+    // the user's `path` resolves to a derivation. Using `drvPath` directly also
+    // bypasses `nix show-derivation`, which cannot resolve floating-output
+    // placeholder paths. The legacy branch below remains for the case where
+    // the user wrote a literal store path string in their `deploy` attribute.
+    let deriver = if let Some(drv_path) = &profile_settings.drv_path {
+        debug!("Using drvPath from flake: {}", drv_path);
+        deriver_for_build(drv_path.clone(), supports_caret).await?
+    } else {
+        debug!(
+            "Finding the deriver of store path for {}",
+            &profile_settings.path
+        );
 
-    match show_derivation_output.status.code() {
-        Some(0) => (),
-        _exit_code => {
-            return Err(PushProfileError::ShowDerivation(
-                command::CommandError::Exit(show_derivation_output, show_derivation_command_str),
-            ));
-        }
-    };
+        // `nix-store --query --deriver` doesn't work on invalid paths, so we parse output of show-derivation :(
+        let mut show_derivation_command = Command::new("nix");
+        show_derivation_command
+            .arg("--experimental-features")
+            .arg("nix-command")
+            .arg("show-derivation")
+            .arg(&profile_settings.path);
+        let show_derivation_command_str = format!("{:?}", show_derivation_command);
 
-    let show_derivation_json: serde_json::value::Value = serde_json::from_str(
-        std::str::from_utf8(&show_derivation_output.stdout).map_err(|err| {
+        let show_derivation_output = command::Command::new(show_derivation_command)
+            .run()
+            .await
+            .map_err(PushProfileError::ShowDerivation)?;
+
+        match show_derivation_output.status.code() {
+            Some(0) => (),
+            _exit_code => {
+                return Err(PushProfileError::ShowDerivation(
+                    command::CommandError::Exit(show_derivation_output, show_derivation_command_str),
+                ));
+            }
+        };
+
+        let show_derivation_json: serde_json::value::Value = serde_json::from_str(
+            std::str::from_utf8(&show_derivation_output.stdout).map_err(|err| {
+                PushProfileError::ShowDerivation(command::CommandError::OtherError(
+                    ShowDerivationError::Utf8(err),
+                ))
+            })?,
+        )
+        .map_err(|err| {
             PushProfileError::ShowDerivation(command::CommandError::OtherError(
-                ShowDerivationError::Utf8(err),
+                ShowDerivationError::Parse(err),
             ))
-        })?,
-    )
-    .map_err(|err| {
-        PushProfileError::ShowDerivation(command::CommandError::OtherError(
-            ShowDerivationError::Parse(err),
-        ))
-    })?;
+        })?;
 
-    // Nix 2.33+ nests derivations under a "derivations" key, so try to get that first
-    let derivation_info = show_derivation_json
-        .get("derivations")
-        .unwrap_or(&show_derivation_json)
-        .as_object()
-        .ok_or(PushProfileError::ShowDerivation(
-            command::CommandError::OtherError(ShowDerivationError::Invalid),
-        ))?;
+        // Nix 2.33+ nests derivations under a "derivations" key, so try to get that first
+        let derivation_info = show_derivation_json
+            .get("derivations")
+            .unwrap_or(&show_derivation_json)
+            .as_object()
+            .ok_or(PushProfileError::ShowDerivation(
+                command::CommandError::OtherError(ShowDerivationError::Invalid),
+            ))?;
 
-    let deriver_key = derivation_info
-        .keys()
-        .next()
-        .ok_or(PushProfileError::ShowDerivation(
-            command::CommandError::OtherError(ShowDerivationError::Empty),
-        ))?;
+        let deriver_key = derivation_info.keys().next().ok_or(
+            PushProfileError::ShowDerivation(command::CommandError::OtherError(
+                ShowDerivationError::Empty,
+            )),
+        )?;
 
-    // Nix 2.32+ returns relative paths (without /nix/store/ prefix) in show-derivation output
-    // Normalize to always use full store paths
-    let deriver = if deriver_key.starts_with("/nix/store/") {
-        deriver_key.to_string()
-    } else {
-        format!("/nix/store/{}", deriver_key)
+        // Nix 2.32+ returns relative paths (without /nix/store/ prefix) in show-derivation output
+        // Normalize to always use full store paths
+        let deriver = if deriver_key.starts_with("/nix/store/") {
+            deriver_key.to_string()
+        } else {
+            format!("/nix/store/{}", deriver_key)
+        };
+
+        deriver_for_build(deriver, supports_caret).await?
     };
 
-    let new_deriver = if data.supports_flakes
-        || data
-            .deploy_data
-            .merged_settings
-            .remote_build
-            .unwrap_or(false)
-    {
-        // Since nix 2.15.0 'nix build <path>.drv' will build only the .drv file itself, not the
-        // derivation outputs, '^out' is used to refer to outputs explicitly
-        deriver.clone() + "^out"
+    if data.deploy_data.merged_settings.remote_build.unwrap_or(false) {
+        if !data.supports_flakes {
+            warn!("remote builds using non-flake nix are experimental");
+        }
+
+        build_profile_remotely(data, &deriver).await
     } else {
-        deriver.clone()
-    };
+        build_profile_locally(data, &deriver).await
+    }
+}
+
+/// Picks the `nix build` argument shape for a given deriver, accounting for the
+/// pre/post 2.15 split: on 2.15 and newer, `nix build <drv>` builds only the
+/// `.drv` itself and `^out` is needed to select outputs; on older Nix,
+/// `nix build <drv>` already builds outputs and `^out` is not understood. We
+/// detect which case applies by asking `nix path-info <drv>`; on 2.15 and newer
+/// it echoes the `.drv` back, while on older versions it resolves to the
+/// realised output or errors out if the output is not yet built.
+async fn deriver_for_build(deriver: String, supports_caret: bool) -> Result<String, PushProfileError> {
+    if !supports_caret {
+        return Ok(deriver);
+    }
 
     let mut path_info_command = Command::new("nix");
     path_info_command
@@ -644,42 +659,84 @@ pub async fn build_profile(data: &PushProfileData) -> Result<(), PushProfileErro
         .await
         .map_err(PushProfileError::PathInfo)?;
 
-    let deriver = if std::str::from_utf8(&path_info_output.stdout).map(|s| s.trim())
-        == Ok(deriver.as_str())
-    {
-        // In this case we're on 2.15.0 or newer, because 'nix path-info <...>.drv'
-        // returns the same '<...>.drv' path.
-        // If 'nix path-info <...>.drv' returns a different path, then we're on pre 2.15.0 nix and
-        // derivation build result is already present in the /nix/store.
-        new_deriver
+    if std::str::from_utf8(&path_info_output.stdout).map(|s| s.trim()) == Ok(deriver.as_str()) {
+        Ok(format!("{}^out", deriver))
     } else {
-        // If 'nix path-info <...>.drv' returns a different path, then we're on pre 2.15.0 nix and
-        // derivation build result is already present in the /nix/store.
-        //
-        // Alternatively, the result of the derivation build may not be yet present
-        // in the /nix/store. In this case, 'nix path-info' returns
-        // 'error: path '...' is not valid'.
-        deriver
-    };
-    if data
-        .deploy_data
-        .merged_settings
-        .remote_build
-        .unwrap_or(false)
-    {
-        if !data.supports_flakes {
-            warn!("remote builds using non-flake nix are experimental");
-        }
-
-        build_profile_remotely(data, &deriver).await?;
-    } else {
-        build_profile_locally(data, &deriver).await?;
+        Ok(deriver)
     }
-
-    Ok(())
 }
 
-pub async fn push_profile(data: &PushProfileData) -> Result<(), PushProfileError> {
+/// Returns the realised `/nix/store/...` path of the profile's output.
+///
+/// For traditional input-addressed derivations the eval-time `path` is already
+/// the realised path, so we just clone it. For content-addressed and
+/// floating-output derivations the eval-time `path` is a placeholder; the
+/// realised path is only known after build, so we ask Nix for it via
+/// `path-info <drv>^out`. When `store_address` is set the query runs against
+/// that remote store.
+async fn resolve_closure(
+    profile_settings: &ProfileSettings,
+    store_address: Option<&str>,
+    ssh_opts: Option<&str>,
+) -> Result<String, PushProfileError> {
+    if profile_settings.path.starts_with("/nix/store/") {
+        return Ok(profile_settings.path.clone());
+    }
+
+    // Placeholder path; the floating output's drvPath is required to resolve it.
+    let drv_path = profile_settings.drv_path.as_deref().ok_or_else(|| {
+        PushProfileError::ResolveClosure(format!(
+            "profile path `{}` is not a `/nix/store/` path and no derivation is associated with it; \
+             set `path` to a derivation such as `deploy-rs.lib.${{system}}.activate.nixos cfg` \
+             rather than a literal string",
+            profile_settings.path
+        ))
+    })?;
+
+    let target = format!("{}^out", drv_path);
+
+    let mut cmd = Command::new("nix");
+    cmd.arg("--experimental-features").arg("nix-command");
+    if let Some(addr) = store_address {
+        cmd.arg("--store").arg(addr);
+    }
+    cmd.arg("path-info").arg(&target);
+    if let Some(opts) = ssh_opts {
+        cmd.env("NIX_SSHOPTS", opts);
+    }
+
+    let output = cmd
+        .output()
+        .await
+        .map_err(|e| PushProfileError::ResolveClosure(e.to_string()))?;
+
+    if !output.status.success() {
+        return Err(PushProfileError::ResolveClosure(format!(
+            "`nix path-info {}` exited with {:?}: {}",
+            target,
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+
+    let resolved = std::str::from_utf8(&output.stdout)
+        .map_err(|e| PushProfileError::ResolveClosure(e.to_string()))?
+        .lines()
+        .next()
+        .ok_or_else(|| {
+            PushProfileError::ResolveClosure(format!(
+                "`nix path-info {}` produced no output",
+                target
+            ))
+        })?
+        .trim()
+        .to_string();
+
+    debug!("Resolved floating output {} to {}", drv_path, resolved);
+    Ok(resolved)
+}
+
+pub async fn push_profile(data: &PushProfileData, closure: &str) -> Result<(), PushProfileError> {
     let ssh_opts_str = data
         .deploy_data
         .merged_settings
@@ -722,7 +779,7 @@ pub async fn push_profile(data: &PushProfileData) -> Result<(), PushProfileError
         copy_command
             .arg("--to")
             .arg(format!("ssh://{}@{}", data.deploy_defs.ssh_user, hostname))
-            .arg(&data.deploy_data.profile.profile_settings.path)
+            .arg(closure)
             .env("NIX_SSHOPTS", ssh_opts_str);
 
         debug!("copy command: {:?}", copy_command);
@@ -760,3 +817,53 @@ pub async fn push_profile(data: &PushProfileData) -> Result<(), PushProfileError
 
     Ok(())
 }
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn settings(path: &str, drv_path: Option<&str>) -> ProfileSettings {
+        ProfileSettings {
+            path: path.to_string(),
+            profile_path: None,
+            drv_path: drv_path.map(str::to_string),
+        }
+    }
+
+    #[tokio::test]
+    async fn input_addressed_path_passes_through_without_shelling_out() {
+        // For traditional /nix/store paths there is nothing to resolve; the
+        // eval value is already the realised closure, so we must not invoke
+        // nix.
+        let s = settings("/nix/store/abc123def456-example", None);
+        let resolved = resolve_closure(&s, None, None)
+            .await
+            .expect("input-addressed path should resolve trivially");
+        assert_eq!(resolved, "/nix/store/abc123def456-example");
+    }
+
+    #[tokio::test]
+    async fn placeholder_without_drv_path_returns_actionable_error() {
+        // The profile path is a floating-output placeholder but no drvPath was
+        // attached, which happens if a user writes a literal placeholder string
+        // in their deploy attribute. The error must surface the bad path and
+        // point at the fix, which is to use a derivation rather than a string.
+        let s = settings("/03vx4812vk1s8y0chf9cky6s2ggmz1vb", None);
+        let err = resolve_closure(&s, None, None).await.expect_err(
+            "placeholder path without drvPath must error before shelling out",
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("/03vx4812vk1s8y0chf9cky6s2ggmz1vb"),
+            "error names the offending path: {}",
+            msg
+        );
+        assert!(
+            msg.contains("derivation"),
+            "error explains the fix involves a derivation: {}",
+            msg
+        );
+    }
+}
+

--- a/src/push.rs
+++ b/src/push.rs
@@ -668,30 +668,38 @@ async fn deriver_for_build(deriver: String, supports_caret: bool) -> Result<Stri
 
 /// Returns the realised `/nix/store/...` path of the profile's output.
 ///
-/// For traditional input-addressed derivations the eval-time `path` is already
-/// the realised path, so we just clone it. For content-addressed and
-/// floating-output derivations the eval-time `path` is a placeholder; the
-/// realised path is only known after build, so we ask Nix for it via
-/// `path-info <drv>^out`. When `store_address` is set the query runs against
-/// that remote store.
+/// Two branches:
+///
+/// * The transform in `nix/transform-deploy.nix` attaches `drvPath` whenever
+///   the user's `path` resolves to a derivation. In that case the eval-time
+///   `path` may be a content-addressed placeholder, a floating-output
+///   placeholder, or, for nested dynamic derivations, a path whose name
+///   ends in `.drv` rather than a real directory. None of those shapes are
+///   usable as a closure without first resolving them, so we always ask
+///   Nix for the realised output via `path-info <drv>^out`. When
+///   `store_address` is set the query runs against that remote store.
+/// * If `drvPath` is absent, the user wrote a literal string in their
+///   `deploy` attribute. We trust that string if it points into `/nix/store`
+///   and otherwise return an actionable error.
 async fn resolve_closure(
     profile_settings: &ProfileSettings,
     store_address: Option<&str>,
     ssh_opts: Option<&str>,
 ) -> Result<String, PushProfileError> {
-    if profile_settings.path.starts_with("/nix/store/") {
-        return Ok(profile_settings.path.clone());
-    }
-
-    // Placeholder path; the floating output's drvPath is required to resolve it.
-    let drv_path = profile_settings.drv_path.as_deref().ok_or_else(|| {
-        PushProfileError::ResolveClosure(format!(
-            "profile path `{}` is not a `/nix/store/` path and no derivation is associated with it; \
-             set `path` to a derivation such as `deploy-rs.lib.${{system}}.activate.nixos cfg` \
-             rather than a literal string",
-            profile_settings.path
-        ))
-    })?;
+    let drv_path = match profile_settings.drv_path.as_deref() {
+        Some(d) => d,
+        None => {
+            if profile_settings.path.starts_with("/nix/store/") {
+                return Ok(profile_settings.path.clone());
+            }
+            return Err(PushProfileError::ResolveClosure(format!(
+                "profile path `{}` is not a `/nix/store/` path and no derivation is associated with it; \
+                 set `path` to a derivation such as `deploy-rs.lib.${{system}}.activate.nixos cfg` \
+                 rather than a literal string",
+                profile_settings.path
+            )));
+        }
+    };
 
     let target = format!("{}^out", drv_path);
 
@@ -863,6 +871,31 @@ mod test {
             msg.contains("derivation"),
             "error explains the fix involves a derivation: {}",
             msg
+        );
+    }
+
+    #[tokio::test]
+    async fn derivation_typed_path_is_resolved_via_drv_path_even_when_path_looks_like_store() {
+        // Nested dynamic derivations produce an eval-time `outPath` of the
+        // form `/nix/store/<hash>-<name>.drv`. The string starts with
+        // `/nix/store/` but is the .drv file itself, not the realised output
+        // directory. Whenever drvPath is attached, the resolver must always
+        // go through `nix path-info <drv>^out` and must not trust the
+        // eval-time `path` verbatim. Confirm by passing in a drvPath that
+        // doesn't exist: the resolver should attempt the resolution and
+        // surface a ResolveClosure error rather than silently returning the
+        // bogus path.
+        let s = settings(
+            "/nix/store/0000000000000000000000000000000000-fake-1.0.drv",
+            Some("/nix/store/0000000000000000000000000000000000-fake-1.0.drv"),
+        );
+        let err = resolve_closure(&s, None, None)
+            .await
+            .expect_err("drv-typed path must be resolved via path-info, not trusted verbatim");
+        assert!(
+            matches!(err, PushProfileError::ResolveClosure(_)),
+            "must error through ResolveClosure: {}",
+            err
         );
     }
 }

--- a/src/push.rs
+++ b/src/push.rs
@@ -136,7 +136,10 @@ pub async fn build_profile_locally(
         // `--print-out-paths` makes `nix build` write the realised output
         // to stdout. `nix-build` writes the path to stdout by default so
         // the flag only applies to the flake branch.
-        build_command.arg("build").arg(derivation_name).arg("--print-out-paths")
+        build_command
+            .arg("build")
+            .arg(derivation_name)
+            .arg("--print-out-paths")
     } else {
         build_command.arg(derivation_name)
     };
@@ -205,7 +208,9 @@ pub async fn build_profile_locally(
             stderr: Vec::new(),
         }
     } else {
-        build_command.stdout(Stdio::piped()).stderr(Stdio::inherit());
+        build_command
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
         command::Command::new(build_command)
             .run()
             .await
@@ -567,7 +572,9 @@ pub async fn build_profile_remotely(
             let stdout = stdout_task
                 .await
                 .map_err(|e| {
-                    PushProfileError::Build(command::CommandError::RunError(std::io::Error::other(e)))
+                    PushProfileError::Build(command::CommandError::RunError(std::io::Error::other(
+                        e,
+                    )))
                 })?
                 .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?;
 
@@ -579,7 +586,9 @@ pub async fn build_profile_remotely(
         } else {
             // No progress bar: let nix write its native output to the terminal.
             debug!("build command: {:?}", build_command);
-            build_command.stdout(Stdio::piped()).stderr(Stdio::inherit());
+            build_command
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit());
             command::Command::new(build_command)
                 .run()
                 .await
@@ -598,7 +607,12 @@ pub async fn build_profile_remotely(
 pub async fn build_profile(data: &PushProfileData) -> Result<String, PushProfileError> {
     let profile_settings = &data.deploy_data.profile.profile_settings;
 
-    let supports_caret = data.supports_flakes || data.deploy_data.merged_settings.remote_build.unwrap_or(false);
+    let supports_caret = data.supports_flakes
+        || data
+            .deploy_data
+            .merged_settings
+            .remote_build
+            .unwrap_or(false);
 
     // The eval transformation in `nix/transform-deploy.nix` attaches `drvPath`
     // to every derivation-typed profile path, so this branch is hit whenever
@@ -633,7 +647,10 @@ pub async fn build_profile(data: &PushProfileData) -> Result<String, PushProfile
             Some(0) => (),
             _exit_code => {
                 return Err(PushProfileError::ShowDerivation(
-                    command::CommandError::Exit(show_derivation_output, show_derivation_command_str),
+                    command::CommandError::Exit(
+                        show_derivation_output,
+                        show_derivation_command_str,
+                    ),
                 ));
             }
         };
@@ -660,11 +677,12 @@ pub async fn build_profile(data: &PushProfileData) -> Result<String, PushProfile
                 command::CommandError::OtherError(ShowDerivationError::Invalid),
             ))?;
 
-        let deriver_key = derivation_info.keys().next().ok_or(
-            PushProfileError::ShowDerivation(command::CommandError::OtherError(
-                ShowDerivationError::Empty,
-            )),
-        )?;
+        let deriver_key = derivation_info
+            .keys()
+            .next()
+            .ok_or(PushProfileError::ShowDerivation(
+                command::CommandError::OtherError(ShowDerivationError::Empty),
+            ))?;
 
         // Nix 2.32+ returns relative paths (without /nix/store/ prefix) in show-derivation output
         // Normalize to always use full store paths
@@ -677,7 +695,12 @@ pub async fn build_profile(data: &PushProfileData) -> Result<String, PushProfile
         deriver_for_build(deriver, supports_caret).await?
     };
 
-    if data.deploy_data.merged_settings.remote_build.unwrap_or(false) {
+    if data
+        .deploy_data
+        .merged_settings
+        .remote_build
+        .unwrap_or(false)
+    {
         if !data.supports_flakes {
             warn!("remote builds using non-flake nix are experimental");
         }
@@ -695,7 +718,10 @@ pub async fn build_profile(data: &PushProfileData) -> Result<String, PushProfile
 /// detect which case applies by asking `nix path-info <drv>`; on 2.15 and newer
 /// it echoes the `.drv` back, while on older versions it resolves to the
 /// realised output or errors out if the output is not yet built.
-async fn deriver_for_build(deriver: String, supports_caret: bool) -> Result<String, PushProfileError> {
+async fn deriver_for_build(
+    deriver: String,
+    supports_caret: bool,
+) -> Result<String, PushProfileError> {
     if !supports_caret {
         return Ok(deriver);
     }
@@ -820,7 +846,6 @@ pub async fn push_profile(data: &PushProfileData, closure: &str) -> Result<(), P
     Ok(())
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -854,4 +879,3 @@ mod test {
         assert!(matches!(err, PushProfileError::BuildStdoutMultiline(_)));
     }
 }
-

--- a/src/push.rs
+++ b/src/push.rs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::data::ProfileSettings;
 use indicatif::ProgressBar;
 use log::{debug, info, warn};
 use std::collections::HashMap;
@@ -98,8 +97,12 @@ pub enum PushProfileError {
              Is there a mismatch in deploy-rs used in the flake you're deploying and deploy-rs command you're running?"
     )]
     ActivateRsDoesntExist,
-    #[error("Failed to resolve floating-output store path via `nix path-info`: {0}")]
-    ResolveClosure(String),
+    #[error("Nix build command output contained an invalid UTF-8 sequence: {0}")]
+    BuildStdoutUtf8(std::str::Utf8Error),
+    #[error("Nix build command succeeded but printed no output path")]
+    BuildStdoutEmpty,
+    #[error("Nix build command printed multiple output paths, expected exactly one: {0}")]
+    BuildStdoutMultiline(String),
 }
 
 #[derive(Clone)]
@@ -130,7 +133,10 @@ pub async fn build_profile_locally(
     };
 
     if data.supports_flakes {
-        build_command.arg("build").arg(derivation_name)
+        // `--print-out-paths` makes `nix build` write the realised output
+        // to stdout. `nix-build` writes the path to stdout by default so
+        // the flag only applies to the flake branch.
+        build_command.arg("build").arg(derivation_name).arg("--print-out-paths")
     } else {
         build_command.arg(derivation_name)
     };
@@ -153,43 +159,65 @@ pub async fn build_profile_locally(
 
     build_command.args(data.extra_build_args.clone());
 
-    build_command
-        // Logging should be in stderr, this just stops the store path from printing for no reason
-        .stdout(Stdio::null());
-
     debug!("build command: {:?}", build_command);
 
-    // When a progress bar is attached, pipe nix's stderr and route each line
-    // through the spinner's message. Otherwise nix detects the terminal and
-    // draws its own `[x/y built]` bar directly, which corrupts the display.
-    let build_status = if let Some(pb) = &data.deploy_data.progressbar {
+    // Capture stdout so we can read the realised store path. When a progress
+    // bar is attached, stderr is also piped and routed through the spinner's
+    // message via `update_pb_with_child_output`; otherwise stderr is left
+    // inherited so nix's native build logs stream straight to the terminal.
+    let build_output = if let Some(pb) = &data.deploy_data.progressbar {
         // `internal-json` gives us structured progress to render in the spinner
         // instead of nix's own (terminal-drawing) progress bar.
         build_command.arg("--log-format").arg("internal-json");
         let mut child = build_command
+            .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
             .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?;
 
+        // The realised store path arrives on stdout as a plain line, while
+        // only stderr carries the `@nix ...` progress events, so read stdout
+        // ourselves while the spinner consumes stderr.
+        let mut stdout = child.stdout.take().expect("stdout was piped");
+        let stdout_task = tokio::spawn(async move {
+            let mut buf = Vec::new();
+            tokio::io::AsyncReadExt::read_to_end(&mut stdout, &mut buf)
+                .await
+                .map(|_| buf)
+        });
+
         update_pb_with_child_output(pb, &mut child).await;
 
-        child
+        let status = child
             .wait()
             .await
-            .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?
+            .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?;
+        let stdout = stdout_task
+            .await
+            .map_err(|e| {
+                PushProfileError::Build(command::CommandError::RunError(std::io::Error::other(e)))
+            })?
+            .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?;
+
+        std::process::Output {
+            status,
+            stdout,
+            stderr: Vec::new(),
+        }
     } else {
+        build_command.stdout(Stdio::piped()).stderr(Stdio::inherit());
         command::Command::new(build_command)
-            .status()
+            .run()
             .await
             .map_err(PushProfileError::Build)?
     };
 
-    match build_status.code() {
+    match build_output.status.code() {
         Some(0) => (),
         a => return Err(PushProfileError::BuildExit(a)),
     };
 
-    let closure = resolve_closure(&data.deploy_data.profile.profile_settings, None, None).await?;
+    let closure = parse_build_out_path(&build_output.stdout)?;
 
     if !Path::new(format!("{}/deploy-rs-activate", closure).as_str()).exists() {
         return Err(PushProfileError::DeployRsActivateDoesntExist);
@@ -496,7 +524,7 @@ pub async fn build_profile_remotely(
         a => return Err(PushProfileError::CopyExit(a)),
     };
 
-    let build_exit_status = {
+    let build_output = {
         let mut build_command = Command::new("nix");
         build_command
             .arg("build")
@@ -505,6 +533,7 @@ pub async fn build_profile_remotely(
             .arg("auto")
             .arg("--store")
             .arg(&store_address)
+            .arg("--print-out-paths")
             .args(data.extra_build_args.clone())
             .env("NIX_SSHOPTS", ssh_opts_str.clone());
 
@@ -518,29 +547,52 @@ pub async fn build_profile_remotely(
                 .spawn()
                 .expect("failed to spawn nix build command");
 
+            // The realised store path arrives on stdout as a plain line,
+            // while only stderr carries the `@nix ...` progress events, so
+            // read stdout ourselves while the spinner consumes stderr.
+            let mut stdout = child.stdout.take().expect("stdout was piped");
+            let stdout_task = tokio::spawn(async move {
+                let mut buf = Vec::new();
+                tokio::io::AsyncReadExt::read_to_end(&mut stdout, &mut buf)
+                    .await
+                    .map(|_| buf)
+            });
+
             update_pb_with_child_output(pb, &mut child).await;
 
-            child
+            let status = child
                 .wait()
                 .await
-                .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?
+                .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?;
+            let stdout = stdout_task
+                .await
+                .map_err(|e| {
+                    PushProfileError::Build(command::CommandError::RunError(std::io::Error::other(e)))
+                })?
+                .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?;
+
+            std::process::Output {
+                status,
+                stdout,
+                stderr: Vec::new(),
+            }
         } else {
             // No progress bar: let nix write its native output to the terminal.
             debug!("build command: {:?}", build_command);
-            build_command
-                .status()
+            build_command.stdout(Stdio::piped()).stderr(Stdio::inherit());
+            command::Command::new(build_command)
+                .run()
                 .await
-                .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?
+                .map_err(PushProfileError::Build)?
         }
     };
 
-    match build_exit_status.code() {
+    match build_output.status.code() {
         Some(0) => (),
         a => return Err(PushProfileError::BuildExit(a)),
     };
 
-    // The realised output lives on the remote store, so resolve it over ssh-ng.
-    resolve_closure(&data.deploy_data.profile.profile_settings, Some(&store_address), Some(&ssh_opts_str)).await
+    parse_build_out_path(&build_output.stdout)
 }
 
 pub async fn build_profile(data: &PushProfileData) -> Result<String, PushProfileError> {
@@ -666,82 +718,24 @@ async fn deriver_for_build(deriver: String, supports_caret: bool) -> Result<Stri
     }
 }
 
-/// Returns the realised `/nix/store/...` path of the profile's output.
+/// Extracts the realised `/nix/store/...` path from `nix build`'s stdout.
 ///
-/// Two branches:
-///
-/// * The transform in `nix/transform-deploy.nix` attaches `drvPath` whenever
-///   the user's `path` resolves to a derivation. In that case the eval-time
-///   `path` may be a content-addressed placeholder, a floating-output
-///   placeholder, or, for nested dynamic derivations, a path whose name
-///   ends in `.drv` rather than a real directory. None of those shapes are
-///   usable as a closure without first resolving them, so we always ask
-///   Nix for the realised output via `path-info <drv>^out`. When
-///   `store_address` is set the query runs against that remote store.
-/// * If `drvPath` is absent, the user wrote a literal string in their
-///   `deploy` attribute. We trust that string if it points into `/nix/store`
-///   and otherwise return an actionable error.
-async fn resolve_closure(
-    profile_settings: &ProfileSettings,
-    store_address: Option<&str>,
-    ssh_opts: Option<&str>,
-) -> Result<String, PushProfileError> {
-    let drv_path = match profile_settings.drv_path.as_deref() {
-        Some(d) => d,
-        None => {
-            if profile_settings.path.starts_with("/nix/store/") {
-                return Ok(profile_settings.path.clone());
-            }
-            return Err(PushProfileError::ResolveClosure(format!(
-                "profile path `{}` is not a `/nix/store/` path and no derivation is associated with it; \
-                 set `path` to a derivation such as `deploy-rs.lib.${{system}}.activate.nixos cfg` \
-                 rather than a literal string",
-                profile_settings.path
-            )));
-        }
-    };
+/// Both `nix build --print-out-paths` and `nix-build` write one path per
+/// line. A deploy-rs build asks for exactly one output, so anything other
+/// than a single non-empty line is rejected rather than silently truncated.
+fn parse_build_out_path(stdout: &[u8]) -> Result<String, PushProfileError> {
+    let text = std::str::from_utf8(stdout).map_err(PushProfileError::BuildStdoutUtf8)?;
+    let trimmed = text.trim();
 
-    let target = format!("{}^out", drv_path);
-
-    let mut cmd = Command::new("nix");
-    cmd.arg("--experimental-features").arg("nix-command");
-    if let Some(addr) = store_address {
-        cmd.arg("--store").arg(addr);
+    if trimmed.is_empty() {
+        return Err(PushProfileError::BuildStdoutEmpty);
     }
-    cmd.arg("path-info").arg(&target);
-    if let Some(opts) = ssh_opts {
-        cmd.env("NIX_SSHOPTS", opts);
+    if trimmed.contains('\n') {
+        return Err(PushProfileError::BuildStdoutMultiline(trimmed.to_string()));
     }
 
-    let output = cmd
-        .output()
-        .await
-        .map_err(|e| PushProfileError::ResolveClosure(e.to_string()))?;
-
-    if !output.status.success() {
-        return Err(PushProfileError::ResolveClosure(format!(
-            "`nix path-info {}` exited with {:?}: {}",
-            target,
-            output.status.code(),
-            String::from_utf8_lossy(&output.stderr).trim()
-        )));
-    }
-
-    let resolved = std::str::from_utf8(&output.stdout)
-        .map_err(|e| PushProfileError::ResolveClosure(e.to_string()))?
-        .lines()
-        .next()
-        .ok_or_else(|| {
-            PushProfileError::ResolveClosure(format!(
-                "`nix path-info {}` produced no output",
-                target
-            ))
-        })?
-        .trim()
-        .to_string();
-
-    debug!("Resolved floating output {} to {}", drv_path, resolved);
-    Ok(resolved)
+    debug!("Built closure {}", trimmed);
+    Ok(trimmed.to_string())
 }
 
 pub async fn push_profile(data: &PushProfileData, closure: &str) -> Result<(), PushProfileError> {
@@ -831,72 +825,33 @@ pub async fn push_profile(data: &PushProfileData, closure: &str) -> Result<(), P
 mod test {
     use super::*;
 
-    fn settings(path: &str, drv_path: Option<&str>) -> ProfileSettings {
-        ProfileSettings {
-            path: path.to_string(),
-            profile_path: None,
-            drv_path: drv_path.map(str::to_string),
-        }
+    #[test]
+    fn parse_build_out_path_returns_single_line() {
+        // The happy path: `nix build --print-out-paths` writes exactly one
+        // store path followed by a newline.
+        let stdout = b"/nix/store/abc123-example\n";
+        let path = parse_build_out_path(stdout).expect("single-line stdout must parse");
+        assert_eq!(path, "/nix/store/abc123-example");
     }
 
-    #[tokio::test]
-    async fn input_addressed_path_passes_through_without_shelling_out() {
-        // For traditional /nix/store paths there is nothing to resolve; the
-        // eval value is already the realised closure, so we must not invoke
-        // nix.
-        let s = settings("/nix/store/abc123def456-example", None);
-        let resolved = resolve_closure(&s, None, None)
-            .await
-            .expect("input-addressed path should resolve trivially");
-        assert_eq!(resolved, "/nix/store/abc123def456-example");
+    #[test]
+    fn parse_build_out_path_rejects_empty_output() {
+        // `nix build` can exit 0 without emitting a realised path under some
+        // dynamic-derivation failure modes. Surfacing the missing closure
+        // here keeps it from being silently fed into a downstream
+        // activate-script check as an empty string.
+        let err = parse_build_out_path(b"").expect_err("empty stdout must error");
+        assert!(matches!(err, PushProfileError::BuildStdoutEmpty));
     }
 
-    #[tokio::test]
-    async fn placeholder_without_drv_path_returns_actionable_error() {
-        // The profile path is a floating-output placeholder but no drvPath was
-        // attached, which happens if a user writes a literal placeholder string
-        // in their deploy attribute. The error must surface the bad path and
-        // point at the fix, which is to use a derivation rather than a string.
-        let s = settings("/03vx4812vk1s8y0chf9cky6s2ggmz1vb", None);
-        let err = resolve_closure(&s, None, None).await.expect_err(
-            "placeholder path without drvPath must error before shelling out",
-        );
-        let msg = err.to_string();
-        assert!(
-            msg.contains("/03vx4812vk1s8y0chf9cky6s2ggmz1vb"),
-            "error names the offending path: {}",
-            msg
-        );
-        assert!(
-            msg.contains("derivation"),
-            "error explains the fix involves a derivation: {}",
-            msg
-        );
-    }
-
-    #[tokio::test]
-    async fn derivation_typed_path_is_resolved_via_drv_path_even_when_path_looks_like_store() {
-        // Nested dynamic derivations produce an eval-time `outPath` of the
-        // form `/nix/store/<hash>-<name>.drv`. The string starts with
-        // `/nix/store/` but is the .drv file itself, not the realised output
-        // directory. Whenever drvPath is attached, the resolver must always
-        // go through `nix path-info <drv>^out` and must not trust the
-        // eval-time `path` verbatim. Confirm by passing in a drvPath that
-        // doesn't exist: the resolver should attempt the resolution and
-        // surface a ResolveClosure error rather than silently returning the
-        // bogus path.
-        let s = settings(
-            "/nix/store/0000000000000000000000000000000000-fake-1.0.drv",
-            Some("/nix/store/0000000000000000000000000000000000-fake-1.0.drv"),
-        );
-        let err = resolve_closure(&s, None, None)
-            .await
-            .expect_err("drv-typed path must be resolved via path-info, not trusted verbatim");
-        assert!(
-            matches!(err, PushProfileError::ResolveClosure(_)),
-            "must error through ResolveClosure: {}",
-            err
-        );
+    #[test]
+    fn parse_build_out_path_rejects_multiple_outputs() {
+        // deploy-rs builds exactly one `out` per profile, so more than one
+        // line on stdout means our invocation has drifted from what the rest
+        // of the pipeline expects. Refuse rather than silently picking one.
+        let stdout = b"/nix/store/a\n/nix/store/b\n";
+        let err = parse_build_out_path(stdout).expect_err("multiline stdout must error");
+        assert!(matches!(err, PushProfileError::BuildStdoutMultiline(_)));
     }
 }
 


### PR DESCRIPTION
I took a shot at resolving the issues with ca-derivations (#164) since I use them quite frequently. This resolves the issues I was having, but you might want to test the changes further. The changes were implemented with help from Claude Opus 4.7. If this is an issue, I would like to make you aware of it.

This branch keeps the user-facing API unchanged. A Nix transformation, applied in both flake and non-flake eval modes, walks `nodes.*.profiles.*`. When `path` evaluates to a derivation, it is transformed such that `path` becomes `outPath` and a sibling `drvPath` is added. The binary picks up the new `drvPath` field on `ProfileSettings` and builds the `.drv` directly. The realised output is then resolved by calling `nix path-info <drv>^out` against the local or remote store. That resolved path is used throughout copy, activate, confirm, and revoke, so no stage falls back to the eval-time placeholder.