### PR TITLE
Update flake.lock and fix 403 on crate.io

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743014863,
-        "narHash": "sha256-jAIUqsiN2r3hCuHji80U7NNEafpIMBXiwKlSrjWMlpg=",
+        "lastModified": 1780365719,
+        "narHash": "sha256-QfWfccTN+70ZQ4m2qlU9PiKfz2Yppq94058iJyARNwc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bd3bac8bfb542dbde7ffffb6987a1a1f9d41699f",
+        "rev": "ffa10e26ae11d676b2db836259889f1f571cb14f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,9 @@
             ".*\.rs$"
           ];
 
-          cargoLock.lockFile = ./Cargo.lock;
+          cargoDeps = final.rustPlatform.importCargoLock {
+            lockFile = ./Cargo.lock;
+          };
 
           meta = {
             description = "A Simple multi-profile Nix-flake deploy tool"; 


### PR DESCRIPTION
nixos-unstable has a work-around for crate.io returning 403 on the requests without user-agent. The Nix's rust package fetcher fetchCargoVendor uses python's requests library which doesn't set agent explicitly. From recently create.io returns 403 on such requests (upstream issues says that nixpkgs has exception but peoples seems to get 403 anyway). cargoLock uses uses fetchurl default curl user-agent which gets blocked by crate.io