### PR TITLE
fix(flake): issues reported by lix's broken-string-escape

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,17 +26,17 @@
           version = "0.1.0";
 
           src = final.lib.sourceByRegex ./. [
-            "Cargo\.lock"
-            "Cargo\.toml"
+            "Cargo\\.lock"
+            "Cargo\\.toml"
             "src"
             "src/bin"
-            ".*\.rs$"
+            ".*\\.rs$"
           ];
 
           cargoLock.lockFile = ./Cargo.lock;
 
           meta = {
-            description = "A Simple multi-profile Nix-flake deploy tool"; 
+            description = "A Simple multi-profile Nix-flake deploy tool";
             mainProgram = "deploy";
           };
         };


### PR DESCRIPTION
Lix 1.95+ warns on `broken-string-escape`, escapes that return the original character. In this case, the regexes where trying to match a literal `.` instead of any character, so they escaped the `.` by writing `\.`.

Since `\.` is not a valid escape, nix parses this as `.`, to follow the intention of the code you need to instead write `\\.`