### PR TITLE
[#379] Fix stdout/stderr supression

### DIFF
--- a/src/bin/activate.rs
+++ b/src/bin/activate.rs
@@ -182,7 +182,7 @@ pub async fn deactivate(profile_path: &str) -> Result<(), DeactivateError> {
         .arg(&profile_path)
         .arg("--rollback");
     command::Command::new(nix_env_rollback_command)
-        .run()
+        .status()
         .await
         .map_err(DeactivateError::Rollback)?;
 
@@ -221,7 +221,7 @@ pub async fn deactivate(profile_path: &str) -> Result<(), DeactivateError> {
         .arg("--delete-generations")
         .arg(last_generation_id);
     command::Command::new(nix_env_delete_generation_command)
-        .run()
+        .status()
         .await
         .map_err(DeactivateError::DeleteGen)?;
 
@@ -232,7 +232,7 @@ pub async fn deactivate(profile_path: &str) -> Result<(), DeactivateError> {
         .env("PROFILE", &profile_path)
         .current_dir(&profile_path);
     command::Command::new(re_activate_command)
-        .run()
+        .status()
         .await
         .map_err(DeactivateError::Reactivate)?;
 
@@ -333,7 +333,11 @@ pub enum WaitError {
     #[error("Error waiting for activation: {0}")]
     Waiting(#[from] DangerZoneError),
 }
-pub async fn wait(temp_path: PathBuf, closure: String, activation_timeout: Option<u16>) -> Result<(), WaitError> {
+pub async fn wait(
+    temp_path: PathBuf,
+    closure: String,
+    activation_timeout: Option<u16>,
+) -> Result<(), WaitError> {
     let lock_path = deploy::make_lock_path(&temp_path, &closure);
 
     let (created, done) = mpsc::channel(1);
@@ -431,20 +435,21 @@ pub async fn activate(
             .arg(&profile_path)
             .arg("--set")
             .arg(&closure);
-        let nix_env_set_exit_output = nix_env_set_command
-            .output()
+        let nix_env_set_exit_status = nix_env_set_command
+            .status()
             .await
-            .map_err(|err| {
-                ActivateError::SetProfile(command::CommandError::RunError(err))
-            })?;
-        match nix_env_set_exit_output.status.code() {
+            .map_err(|err| ActivateError::SetProfile(command::CommandError::RunError(err)))?;
+        match nix_env_set_exit_status.code() {
             Some(0) => (),
             _exit_code => {
                 if auto_rollback && !dry_activate {
                     deactivate(&profile_path).await?;
                 }
                 return Err(ActivateError::SetProfile(
-                    command::CommandError::Exit(nix_env_set_exit_output, format!("{:?}", nix_env_set_command))
+                    command::CommandError::ExitStatus(
+                        nix_env_set_exit_status,
+                        format!("{:?}", nix_env_set_command),
+                    ),
                 ));
             }
         };
@@ -464,12 +469,10 @@ pub async fn activate(
         .env("DRY_ACTIVATE", if dry_activate { "1" } else { "0" })
         .env("BOOT", if boot { "1" } else { "0" })
         .current_dir(activation_location);
-    let activate_output = match activate_command
-        .output()
+    let activate_status = match activate_command
+        .status()
         .await
-        .map_err(|err| {
-            ActivateError::RunActivate(command::CommandError::RunError(err))
-        })
+        .map_err(|err| ActivateError::RunActivate(command::CommandError::RunError(err)))
     {
         Ok(x) => x,
         Err(e) => {
@@ -481,14 +484,17 @@ pub async fn activate(
     };
 
     if !dry_activate {
-        match activate_output.status.code() {
+        match activate_status.code() {
             Some(0) => (),
             _exit_code => {
                 if auto_rollback {
                     deactivate(&profile_path).await?;
                 }
                 return Err(ActivateError::RunActivate(
-                    command::CommandError::Exit(activate_output, format!("{:?}", activate_command))
+                    command::CommandError::ExitStatus(
+                        activate_status,
+                        format!("{:?}", activate_command),
+                    ),
                 ));
             }
         };
@@ -609,9 +615,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await
         .map_err(|x| Box::new(x) as Box<dyn std::error::Error>),
 
-        SubCommand::Wait(wait_opts) => wait(wait_opts.temp_path, wait_opts.closure, wait_opts.activation_timeout)
-            .await
-            .map_err(|x| Box::new(x) as Box<dyn std::error::Error>),
+        SubCommand::Wait(wait_opts) => wait(
+            wait_opts.temp_path,
+            wait_opts.closure,
+            wait_opts.activation_timeout,
+        )
+        .await
+        .map_err(|x| Box::new(x) as Box<dyn std::error::Error>),
 
         SubCommand::Revoke(revoke_opts) => revoke(get_profile_path(
             revoke_opts.profile_path,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use std::io::{stdin, stdout, Write};
 
-use clap::{ArgMatches, Parser, FromArgMatches};
+use clap::{ArgMatches, FromArgMatches, Parser};
 
 use crate as deploy;
 use crate::command;
@@ -166,7 +166,10 @@ async fn check_deployment(
 
     check_command.args(extra_build_args);
 
-    command::Command::new(check_command).run().await.map_err(CheckDeploymentError::NixCheck)?;
+    command::Command::new(check_command)
+        .status()
+        .await
+        .map_err(CheckDeploymentError::NixCheck)?;
 
     Ok(())
 }
@@ -209,7 +212,8 @@ async fn get_deployment_data(
     };
 
     if supports_flakes {
-        eval_command.arg("eval")
+        eval_command
+            .arg("eval")
             .arg("--json")
             .arg(format!("{}#deploy", flake.repo))
             // We use --apply instead of --expr so that we don't have to deal with builtins.getFlake
@@ -263,14 +267,26 @@ async fn get_deployment_data(
             .arg(format!("let r = import {}/.; in if builtins.isFunction r then (r {{}}).deploy else r.deploy", flake.repo))
     };
 
-    eval_command
-        .args(extra_build_args)
-        .stdout(Stdio::piped());
+    eval_command.args(extra_build_args).stdout(Stdio::piped());
 
-    let build_output = command::Command::new(eval_command)
-        .run()
+    let build_child = eval_command
+        .stdout(Stdio::piped())
+        .spawn()
+        .map_err(|err| GetDeploymentDataError::NixEval(command::CommandError::RunError(err)))?;
+
+    let build_output = build_child
+        .wait_with_output()
         .await
-        .map_err(GetDeploymentDataError::NixEval)?;
+        .map_err(|err| GetDeploymentDataError::NixEval(command::CommandError::RunError(err)))?;
+
+    match build_output.status.code() {
+        Some(0) => (),
+        _exit_code => {
+            return Err(GetDeploymentDataError::NixEval(
+                command::CommandError::Exit(build_output, format!("{:?}", eval_command)),
+            ))
+        }
+    }
 
     let data_json = String::from_utf8(build_output.stdout)?;
 
@@ -387,9 +403,9 @@ pub enum RunDeployError {
     #[error("Failed to deploy profile to node {0}: {1}")]
     DeployProfile(String, deploy::deploy::DeployProfileError),
     #[error("Failed to build profile on node {0}: {1}")]
-    BuildProfile(String,  deploy::push::PushProfileError),
+    BuildProfile(String, deploy::push::PushProfileError),
     #[error("Failed to push profile to node {0}: {1}")]
-    PushProfile(String,  deploy::push::PushProfileError),
+    PushProfile(String, deploy::push::PushProfileError),
     #[error("No profile named `{0}` was found")]
     ProfileNotFound(String),
     #[error("No node named `{0}` was found")]
@@ -405,7 +421,7 @@ pub enum RunDeployError {
     #[error("Failed to revoke profile for node {0}: {1}")]
     RevokeProfile(String, deploy::deploy::RevokeProfileError),
     #[error("Deployment to node {0} failed, rolled back to previous generation")]
-    Rollback(String)
+    Rollback(String),
 }
 
 type ToDeploy<'a> = Vec<(
@@ -549,7 +565,11 @@ async fn run_deploy(
 
         let mut deploy_defs = deploy_data.defs()?;
 
-        if deploy_data.merged_settings.interactive_sudo.unwrap_or(false) {
+        if deploy_data
+            .merged_settings
+            .interactive_sudo
+            .unwrap_or(false)
+        {
             warn!("Interactive sudo is enabled! Using a sudo password is less secure than correctly configured SSH keys.\nPlease use keys in production environments.");
 
             if deploy_data.merged_settings.sudo.is_some() {
@@ -561,8 +581,15 @@ async fn run_deploy(
                 deploy_defs.sudo = Some(format!("{} -S -p \"\"", original));
             }
 
-            info!("You will now be prompted for the sudo password for {}.", node.node_settings.hostname);
-            let sudo_password = rpassword::prompt_password(format!("(sudo for {}) Password: ", node.node_settings.hostname)).unwrap_or("".to_string());
+            info!(
+                "You will now be prompted for the sudo password for {}.",
+                node.node_settings.hostname
+            );
+            let sudo_password = rpassword::prompt_password(format!(
+                "(sudo for {}) Password: ",
+                node.node_settings.hostname
+            ))
+            .unwrap_or("".to_string());
 
             deploy_defs.sudo_password = Some(sudo_password);
         }
@@ -593,16 +620,16 @@ async fn run_deploy(
 
     for data in data_iter() {
         let node_name: String = data.deploy_data.node_name.to_string();
-        deploy::push::build_profile(data).await.map_err(|e| {
-            RunDeployError::BuildProfile(node_name, e)
-        })?;
+        deploy::push::build_profile(data)
+            .await
+            .map_err(|e| RunDeployError::BuildProfile(node_name, e))?;
     }
 
     for data in data_iter() {
         let node_name: String = data.deploy_data.node_name.to_string();
-        deploy::push::push_profile(data).await.map_err(|e| {
-            RunDeployError::PushProfile(node_name, e)
-        })?;
+        deploy::push::push_profile(data)
+            .await
+            .map_err(|e| RunDeployError::PushProfile(node_name, e))?;
     }
 
     let mut succeeded: Vec<(&deploy::DeployData, &deploy::DeployDefs)> = vec![];
@@ -612,7 +639,8 @@ async fn run_deploy(
     // Rollbacks adhere to the global seeting to auto_rollback and secondary
     // the profile's configuration
     for (_, deploy_data, deploy_defs) in &parts {
-        if let Err(e) = deploy::deploy::deploy_profile(deploy_data, deploy_defs, dry_activate, boot).await
+        if let Err(e) =
+            deploy::deploy::deploy_profile(deploy_data, deploy_defs, dry_activate, boot).await
         {
             error!("{}", e);
             if dry_activate {
@@ -625,14 +653,19 @@ async fn run_deploy(
                 //  the command line)
                 for (deploy_data, deploy_defs) in &succeeded {
                     if deploy_data.merged_settings.auto_rollback.unwrap_or(true) {
-                        deploy::deploy::revoke(*deploy_data, *deploy_defs).await.map_err(|e| {
-                            RunDeployError::RevokeProfile(deploy_data.node_name.to_string(), e)
-                        })?;
+                        deploy::deploy::revoke(*deploy_data, *deploy_defs)
+                            .await
+                            .map_err(|e| {
+                                RunDeployError::RevokeProfile(deploy_data.node_name.to_string(), e)
+                            })?;
                     }
                 }
                 return Err(RunDeployError::Rollback(deploy_data.node_name.to_string()));
             }
-            return Err(RunDeployError::DeployProfile(deploy_data.node_name.to_string(), e))
+            return Err(RunDeployError::DeployProfile(
+                deploy_data.node_name.to_string(),
+                e,
+            ));
         }
         succeeded.push((deploy_data, deploy_defs))
     }
@@ -683,18 +716,16 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
         .targets
         .unwrap_or_else(|| vec![opts.clone().target.unwrap_or_else(|| ".".to_string())]);
 
-    let deploy_flakes: Vec<DeployFlake> =
-        if let Some(file) = &opts.file {
-            deploys
-                .iter()
-                .map(|f| deploy::parse_file(file.as_str(), f.as_str()))
-                .collect::<Result<Vec<DeployFlake>, ParseFlakeError>>()?
-        }
-    else {
+    let deploy_flakes: Vec<DeployFlake> = if let Some(file) = &opts.file {
         deploys
-        .iter()
-        .map(|f| deploy::parse_flake(f.as_str()))
-          .collect::<Result<Vec<DeployFlake>, ParseFlakeError>>()?
+            .iter()
+            .map(|f| deploy::parse_file(file.as_str(), f.as_str()))
+            .collect::<Result<Vec<DeployFlake>, ParseFlakeError>>()?
+    } else {
+        deploys
+            .iter()
+            .map(|f| deploy::parse_flake(f.as_str()))
+            .collect::<Result<Vec<DeployFlake>, ParseFlakeError>>()?
     };
 
     let cmd_overrides = deploy::CmdOverrides {
@@ -711,7 +742,7 @@ pub async fn run(args: Option<&ArgMatches>) -> Result<(), RunError> {
         dry_activate: opts.dry_activate,
         remote_build: opts.remote_build,
         sudo: opts.sudo,
-        interactive_sudo: opts.interactive_sudo
+        interactive_sudo: opts.interactive_sudo,
     };
 
     let supports_flakes = test_flake_support().await.map_err(RunError::FlakeTest)?;

--- a/src/command.rs
+++ b/src/command.rs
@@ -11,6 +11,7 @@ pub trait HasCommandError {
 pub enum CommandError<T: fmt::Debug + fmt::Display + HasCommandError> {
     RunError(std::io::Error),
     Exit(std::process::Output, String),
+    ExitStatus(std::process::ExitStatus, String),
     OtherError(T),
 }
 
@@ -27,11 +28,20 @@ impl<T: fmt::Debug + fmt::Display + HasCommandError> fmt::Display for CommandErr
                 };
                 write!(
                     f,
-                    "{} command resulted in a bad exit code: {:?}. The failed command is provided below:\n{}\nThe stderr output is provided below:\n{}",
+                    "{} command resulted in a bad exit status: {}. The failed command is provided below:\n{}\nThe stderr output is provided below:\n{}",
                     T::title(),
-                    output.status.code(),
+                    output.status,
                     unescape::unescape(cmd).unwrap_or(cmd.clone()),
                     stderr,
+                )
+            }
+            CommandError::ExitStatus(status, cmd) => {
+                write!(
+                    f,
+                    "{} command resulted in a bad exit status: {}. The failed command is provided below:\n{}",
+                    T::title(),
+                    status,
+                    unescape::unescape(cmd).unwrap_or(cmd.clone()),
                 )
             }
             CommandError::OtherError(err) => write!(f, "{}", err),
@@ -61,6 +71,23 @@ impl Command {
         match output.status.code() {
             Some(0) => Ok(output),
             _exit_code => Err(CommandError::Exit(output, format!("{:?}", self.command))),
+        }
+    }
+
+    pub async fn status<T: fmt::Debug + fmt::Display + HasCommandError>(
+        &mut self,
+    ) -> Result<std::process::ExitStatus, CommandError<T>> {
+        let status = self
+            .command
+            .status()
+            .await
+            .map_err(CommandError::RunError)?;
+        match status.code() {
+            Some(0) => Ok(status),
+            _exit_code => Err(CommandError::ExitStatus(
+                status,
+                format!("{:?}", self.command),
+            )),
         }
     }
 }

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -327,17 +327,17 @@ pub async fn confirm_profile(
             .map_err(|err| ConfirmProfileError::SSHConfirm(command::CommandError::RunError(err)))?;
     }
 
-    let ssh_confirm_exit_output = ssh_confirm_child
-        .wait_with_output()
+    let ssh_confirm_exit_status = ssh_confirm_child
+        .wait()
         .await
         .map_err(|err| ConfirmProfileError::SSHConfirm(command::CommandError::RunError(err)))?;
 
-    match ssh_confirm_exit_output.status.code() {
+    match ssh_confirm_exit_status.code() {
         Some(0) => (),
         _exit_code => {
             return Err(ConfirmProfileError::SSHConfirm(
-                command::CommandError::Exit(
-                    ssh_confirm_exit_output,
+                command::CommandError::ExitStatus(
+                    ssh_confirm_exit_status,
                     format!("{:?}", ssh_confirm_command),
                 ),
             ))
@@ -472,15 +472,15 @@ pub async fn deploy_profile(
         }
 
         let ssh_activate_exit_status = ssh_activate_child
-            .wait_with_output()
+            .wait()
             .await
             .map_err(|err| DeployProfileError::SSHActivate(command::CommandError::RunError(err)))?;
 
-        match ssh_activate_exit_status.status.code() {
+        match ssh_activate_exit_status.code() {
             Some(0) => (),
             _exit_code => {
                 return Err(DeployProfileError::SSHActivate(
-                    command::CommandError::Exit(
+                    command::CommandError::ExitStatus(
                         ssh_activate_exit_status,
                         format!("{:?}", ssh_activate_command),
                     ),
@@ -591,13 +591,13 @@ pub async fn deploy_profile(
         }
 
         tokio::select! {
-            x = ssh_wait_child.wait_with_output() => {
+            x = ssh_wait_child.wait() => {
                 debug!("Wait command ended");
-                let output = x.map_err(|err| DeployProfileError::SSHWait(command::CommandError::RunError(err)))?;
-                match output.status.code() {
+                let status = x.map_err(|err| DeployProfileError::SSHWait(command::CommandError::RunError(err)))?;
+                match status.code() {
                     Some(0) => (),
                     _exit_code => return Err(DeployProfileError::SSHWait(
-                        command::CommandError::Exit(output, format!("{:?}", ssh_wait_command))
+                        command::CommandError::ExitStatus(status, format!("{:?}", ssh_wait_command))
                     )),
                 };
             },

--- a/src/push.rs
+++ b/src/push.rs
@@ -137,7 +137,7 @@ pub async fn build_profile_locally(
         .stdout(Stdio::null());
 
     command::Command::new(build_command)
-        .run()
+        .status()
         .await
         .map_err(PushProfileError::Build)?;
 
@@ -179,7 +179,7 @@ pub async fn build_profile_locally(
             .arg(local_key)
             .arg(&data.deploy_data.profile.profile_settings.path);
         command::Command::new(sign_command)
-            .run()
+            .status()
             .await
             .map_err(PushProfileError::Sign)?;
     }
@@ -210,7 +210,7 @@ pub async fn build_profile_remotely(
         .arg("--experimental-features")
         .arg("nix-command")
         .arg("copy")
-        .arg("-s") // fetch dependencies from substitures, not localhost
+        .arg("-s") // fetch dependencies from substitutes, not localhost
         .arg("--to")
         .arg(&store_address)
         .arg("--derivation")
@@ -218,7 +218,7 @@ pub async fn build_profile_remotely(
         .env("NIX_SSHOPTS", ssh_opts_str.clone())
         .stdout(Stdio::null());
     command::Command::new(copy_command)
-        .run()
+        .status()
         .await
         .map_err(PushProfileError::Copy)?;
 
@@ -240,7 +240,7 @@ pub async fn build_profile_remotely(
     debug!("build command: {:?}", build_command);
 
     command::Command::new(build_command)
-        .run()
+        .status()
         .await
         .map_err(PushProfileError::Build)?;
 
@@ -419,7 +419,7 @@ pub async fn push_profile(data: PushProfileData<'_>) -> Result<(), PushProfileEr
             .arg(&data.deploy_data.profile.profile_settings.path)
             .env("NIX_SSHOPTS", ssh_opts_str);
         command::Command::new(copy_command)
-            .run()
+            .status()
             .await
             .map_err(PushProfileError::Copy)?;
     }


### PR DESCRIPTION
Fixes #379.

This PR restores the old semantics regarding child process handling and stdout/stderr modes. In #310, we were too eager to use `output` on processes rather than `spawn` where needed, causing the stdout/stderr to appear "hanged" rather than directly printed.

See the commit messages for more details.