### PR TITLE
Lint/CI gates, panic hardening, activate.profile, nullable schema

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Serokell <https://serokell.io/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
 name: Nix flake check
 on: pull_request
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,15 @@ This is the core of how `deploy-rs` was designed, any number of these can run on
 }
 ```
 
+The `deploy-rs.lib.<system>.activate` set provides a helper for each kind of profile:
+
+- `activate.nixos <nixosConfiguration>` — activate a NixOS system (runs `switch-to-configuration`).
+- `activate.home-manager <hmConfiguration>` — activate a home-manager generation.
+- `activate.darwin <darwinConfiguration>` — activate a nix-darwin system.
+- `activate.custom <drv> "<activation command>"` — wrap any derivation with a custom activation script (as shown above).
+- `activate.profile <drv>` — install a package (or `buildEnv`) into the target user's nix3 `nix profile`, replacing any previous generation with the same name.
+- `activate.noop <drv>` — deploy the closure without running any activation.
+
 ### Node
 
 This defines a single node/server, and the profiles you intend it to run.

--- a/examples/simple/flake.nix
+++ b/examples/simple/flake.nix
@@ -12,7 +12,7 @@
       hostname = "localhost";
       profiles.hello = {
         user = "balsoft";
-        path = deploy-rs.lib.x86_64-linux.setActivate nixpkgs.legacyPackages.x86_64-linux.hello "./bin/hello";
+        path = deploy-rs.lib.x86_64-linux.activate.custom nixpkgs.legacyPackages.x86_64-linux.hello "./bin/hello";
       };
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -184,6 +184,33 @@
 
         checks = {
           deploy-rs = self.packages.${system}.default.overrideAttrs (super: { doCheck = true; });
+
+          # Lint the Rust sources with clippy, failing on any warning.
+          clippy = self.packages.${system}.default.overrideAttrs (super: {
+            pname = "deploy-rs-clippy";
+            nativeBuildInputs = (super.nativeBuildInputs or [ ]) ++ [ pkgs.clippy ];
+            buildPhase = "cargo clippy --all-targets -- --deny warnings";
+            doCheck = false;
+            installPhase = "touch $out";
+          });
+
+          # Enforce `cargo fmt` formatting.
+          rustfmt = pkgs.runCommandLocal "deploy-rs-rustfmt" {
+            nativeBuildInputs = [ pkgs.cargo pkgs.rustfmt ];
+          } ''
+            export HOME="$TMPDIR"
+            cd ${self.packages.${system}.default.src}
+            cargo fmt --check
+            touch $out
+          '';
+
+          # Enforce REUSE licensing compliance.
+          reuse = pkgs.runCommandLocal "deploy-rs-reuse" {
+            nativeBuildInputs = [ pkgs.reuse ];
+          } ''
+            reuse --root ${self} lint
+            touch $out
+          '';
         } // (pkgs.lib.optionalAttrs (pkgs.lib.elem system ["x86_64-linux"]) (import ./nix/tests {
           inherit inputs pkgs;
         }));

--- a/flake.nix
+++ b/flake.nix
@@ -116,6 +116,21 @@
             darwin = base: custom base.config.system.build.toplevel "HOME=/var/root $PROFILE/activate";
 
             noop = base: custom base ":";
+
+            # Install a package into the target's nix3 profile (`nix profile`).
+            # Unlike the other activators this does not just `nix-env --set` the
+            # closure into deploy-rs' own profile, it also (re)installs `base`
+            # into the calling user's `nix profile`, replacing a previous
+            # generation with the same name. Useful for declaratively rolling
+            # out a package (or a `buildEnv`) to a machine.
+            profile = base: custom base ''
+              export PATH="${final.lib.makeBinPath [ final.nix ]}:$PATH"
+              nixFlags=(--extra-experimental-features "nix-command flakes")
+              # Best-effort removal of a previously-installed element of the same
+              # name (no-op on first deploy), then install the new closure.
+              nix "''${nixFlags[@]}" profile remove "${base.name}" 2>/dev/null || true
+              nix "''${nixFlags[@]}" profile install "${base}"
+            '';
           };
 
           deployChecks = deploy: builtins.mapAttrs (_: check: check deploy) {

--- a/interface.json
+++ b/interface.json
@@ -7,10 +7,10 @@
             "type": "object",
             "properties": {
                 "sshUser": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "user": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "sshOpts": {
                     "type": "array",
@@ -19,25 +19,25 @@
                     }
                 },
                 "fastConnection": {
-                    "type": "boolean"
+                    "type": ["boolean", "null"]
                 },
                 "autoRollback": {
-                    "type": "boolean"
+                    "type": ["boolean", "null"]
                 },
                 "magicRollback": {
-                    "type": "boolean"
+                    "type": ["boolean", "null"]
                 },
                 "confirmTimeout": {
-                    "type": "integer"
+                    "type": ["integer", "null"]
                 },
                 "activationTimeout": {
-                    "type": "integer"
+                    "type": ["integer", "null"]
                 },
                 "tempPath": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "interactiveSudo": {
-                    "type": "boolean"
+                    "type": ["boolean", "null"]
                 }
             }
         },
@@ -82,7 +82,7 @@
                     "type": "string"
                 },
                 "profilePath": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 }
             },
             "required": [

--- a/src/bin/activate.rs
+++ b/src/bin/activate.rs
@@ -179,7 +179,7 @@ pub async fn deactivate(profile_path: &str) -> Result<(), DeactivateError> {
     let mut nix_env_rollback_command = Command::new("nix-env");
     nix_env_rollback_command
         .arg("-p")
-        .arg(&profile_path)
+        .arg(profile_path)
         .arg("--rollback");
     command::Command::new(nix_env_rollback_command)
         .status()
@@ -191,7 +191,7 @@ pub async fn deactivate(profile_path: &str) -> Result<(), DeactivateError> {
     let mut nix_env_list_generations_command = Command::new("nix-env");
     nix_env_list_generations_command
         .arg("-p")
-        .arg(&profile_path)
+        .arg(profile_path)
         .arg("--list-generations");
     let nix_env_list_generations_out = command::Command::new(nix_env_list_generations_command)
         .run()
@@ -217,7 +217,7 @@ pub async fn deactivate(profile_path: &str) -> Result<(), DeactivateError> {
     let mut nix_env_delete_generation_command = Command::new("nix-env");
     nix_env_delete_generation_command
         .arg("-p")
-        .arg(&profile_path)
+        .arg(profile_path)
         .arg("--delete-generations")
         .arg(last_generation_id);
     command::Command::new(nix_env_delete_generation_command)
@@ -229,8 +229,8 @@ pub async fn deactivate(profile_path: &str) -> Result<(), DeactivateError> {
 
     let mut re_activate_command = Command::new(format!("{}/deploy-rs-activate", profile_path));
     re_activate_command
-        .env("PROFILE", &profile_path)
-        .current_dir(&profile_path);
+        .env("PROFILE", profile_path)
+        .current_dir(profile_path);
     command::Command::new(re_activate_command)
         .status()
         .await
@@ -323,7 +323,7 @@ pub async fn activation_confirmation(
 
     danger_zone(done, confirm_timeout)
         .await
-        .map_err(|err| ActivationConfirmationError::WaitingError(err))
+        .map_err(ActivationConfirmationError::WaitingError)
 }
 
 #[derive(Error, Debug)]
@@ -417,6 +417,7 @@ pub enum ActivateError {
     ActivationConfirmation(#[from] ActivationConfirmationError),
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn activate(
     profile_path: String,
     closure: String,
@@ -561,9 +562,7 @@ fn get_profile_path(
                         // using 'dirs::state_dir()' directly.
                         let state_dir = env::var("XDG_STATE_HOME").or_else(|_| {
                             dirs::home_dir()
-                                .map(|h| {
-                                    format!("{}/.local/state", h.as_path().display().to_string())
-                                })
+                                .map(|h| format!("{}/.local/state", h.as_path().display()))
                                 .ok_or(GetProfilePathError::NoUserHome(profile_user))
                         })?;
                         Ok(format!("{}/nix/profiles/{}", state_dir, profile_name))
@@ -578,7 +577,7 @@ fn get_profile_path(
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Ensure that this process stays alive after the SSH connection dies
-    let mut signals = Signals::new(&[SIGHUP])?;
+    let mut signals = Signals::new([SIGHUP])?;
     std::thread::spawn(move || {
         for _ in signals.forever() {
             println!("Received SIGHUP - ignoring...");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -315,7 +315,7 @@ fn print_deployment(
     for (_, data, defs) in parts {
         part_map
             .entry(data.node_name.to_string())
-            .or_insert_with(HashMap::new)
+            .or_default()
             .insert(
                 data.profile_name.to_string(),
                 PromptPart {
@@ -431,6 +431,7 @@ type ToDeploy<'a> = Vec<(
     (&'a str, &'a deploy::data::Profile),
 )>;
 
+#[allow(clippy::too_many_arguments)]
 async fn run_deploy(
     deploy_flakes: Vec<deploy::DeployFlake<'_>>,
     data: Vec<deploy::data::Data>,
@@ -653,7 +654,7 @@ async fn run_deploy(
                 //  the command line)
                 for (deploy_data, deploy_defs) in &succeeded {
                     if deploy_data.merged_settings.auto_rollback.unwrap_or(true) {
-                        deploy::deploy::revoke(*deploy_data, *deploy_defs)
+                        deploy::deploy::revoke(deploy_data, deploy_defs)
                             .await
                             .map_err(|e| {
                                 RunDeployError::RevokeProfile(deploy_data.node_name.to_string(), e)

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Serokell <https://serokell.io/>
+//
+// SPDX-License-Identifier: MPL-2.0
+
 use std::fmt;
 use std::fmt::Debug;
 use thiserror::Error;

--- a/src/data.rs
+++ b/src/data.rs
@@ -33,7 +33,7 @@ pub struct GenericSettings {
     pub magic_rollback: Option<bool>,
     #[serde(rename(deserialize = "sudo"))]
     pub sudo: Option<String>,
-    #[serde(default,rename(deserialize = "remoteBuild"))]
+    #[serde(default, rename(deserialize = "remoteBuild"))]
     pub remote_build: Option<bool>,
     #[serde(rename(deserialize = "interactiveSudo"))]
     pub interactive_sudo: Option<bool>,

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -262,8 +262,7 @@ async fn handle_sudo_stdin(
                 .await;
             Ok(())
         }
-        None => Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
+        None => Err(std::io::Error::other(
             "Failed to open stdin for sudo command",
         )),
     }
@@ -419,7 +418,7 @@ pub async fn deploy_profile(
         profile_info: &deploy_data.get_profile_info()?,
         closure: &deploy_data.profile.profile_settings.path,
         auto_rollback,
-        temp_path: temp_path,
+        temp_path,
         confirm_timeout,
         magic_rollback,
         debug_logs: deploy_data.debug_logs,
@@ -443,7 +442,7 @@ pub async fn deploy_profile(
         .stdin(std::process::Stdio::piped());
 
     for ssh_opt in &deploy_data.merged_settings.ssh_opts {
-        ssh_activate_command.arg(&ssh_opt);
+        ssh_activate_command.arg(ssh_opt);
     }
 
     if !magic_rollback || dry_activate || boot {
@@ -499,8 +498,8 @@ pub async fn deploy_profile(
         let self_wait_command = build_wait_command(&WaitCommandData {
             sudo: &deploy_defs.sudo,
             closure: &deploy_data.profile.profile_settings.path,
-            temp_path: temp_path,
-            activation_timeout: activation_timeout,
+            temp_path,
+            activation_timeout,
             debug_logs: deploy_data.debug_logs,
             log_dir: deploy_data.log_dir,
         });
@@ -672,7 +671,7 @@ pub async fn revoke(
         .stdin(std::process::Stdio::piped());
 
     for ssh_opt in &deploy_data.merged_settings.ssh_opts {
-        ssh_activate_command.arg(&ssh_opt);
+        ssh_activate_command.arg(ssh_opt);
     }
 
     let mut ssh_revoke_child = ssh_activate_command

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -563,10 +563,11 @@ pub async fn deploy_profile(
             };
 
             if let Some(err) = maybe_err {
-                send_activate.send(err).unwrap();
+                // The receiver is gone if the main task already returned; that is fine.
+                let _ = send_activate.send(err);
             }
 
-            send_activated.send(()).unwrap();
+            let _ = send_activated.send(());
         });
 
         let mut ssh_wait_child = ssh_wait_command
@@ -601,8 +602,15 @@ pub async fn deploy_profile(
                 };
             },
             x = recv_activate => {
-                debug!("Activate command exited with an error");
-                return Err(x.unwrap());
+                match x {
+                    Ok(err) => {
+                        debug!("Activate command exited with an error");
+                        return Err(err);
+                    }
+                    // The sender was dropped without sending an error, which means
+                    // activation finished successfully before the wait command returned.
+                    Err(_) => debug!("Activation finished before the wait command returned"),
+                }
             },
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,7 @@ use flexi_logger::*;
 use std::path::{Path, PathBuf};
 
 pub fn make_lock_path(temp_path: &Path, closure: &str) -> PathBuf {
-    let lock_hash =
-        &closure["/nix/store/".len()..closure.find('-').unwrap_or_else(|| closure.len())];
+    let lock_hash = &closure["/nix/store/".len()..closure.find('-').unwrap_or(closure.len())];
     temp_path.join(format!("deploy-rs-canary-{}", lock_hash))
 }
 
@@ -327,7 +326,7 @@ pub fn parse_file<'a>(
     let (node, profile) = parse_fragment(attribute)?;
 
     Ok(DeployFlake {
-        repo: &file,
+        repo: file,
         node,
         profile,
     })
@@ -432,8 +431,9 @@ impl<'a> DeployData<'a> {
     }
 }
 
-pub fn make_deploy_data<'a, 's>(
-    top_settings: &'s data::GenericSettings,
+#[allow(clippy::too_many_arguments)]
+pub fn make_deploy_data<'a>(
+    top_settings: &data::GenericSettings,
     node: &'a data::Node,
     node_name: &'a str,
     profile: &'a data::Profile,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,17 +207,34 @@ fn parse_fragment(fragment: &str) -> Result<(Option<String>, Option<String>), Pa
             (TOKEN_DOT, true) => {
                 return Err(ParseFlakeError::PathTooLong);
             }
-            (NODE_IDENT, _) => Some(entry.into_node().unwrap().text().to_string()),
-            (TOKEN_IDENT, _) => Some(entry.into_token().unwrap().text().to_string()),
+            (NODE_IDENT, _) => Some(
+                entry
+                    .into_node()
+                    .ok_or(ParseFlakeError::Unrecognized)?
+                    .text()
+                    .to_string(),
+            ),
+            (TOKEN_IDENT, _) => Some(
+                entry
+                    .into_token()
+                    .ok_or(ParseFlakeError::Unrecognized)?
+                    .text()
+                    .to_string(),
+            ),
             (NODE_STRING, _) => {
                 let c = entry
                     .into_node()
-                    .unwrap()
+                    .ok_or(ParseFlakeError::Unrecognized)?
                     .children_with_tokens()
                     .nth(1)
-                    .unwrap();
+                    .ok_or(ParseFlakeError::Unrecognized)?;
 
-                Some(c.into_token().unwrap().text().to_string())
+                Some(
+                    c.into_token()
+                        .ok_or(ParseFlakeError::Unrecognized)?
+                        .text()
+                        .to_string(),
+                )
             }
             _ => return Err(ParseFlakeError::Unrecognized),
         };


### PR DESCRIPTION
A batch of small, **non-breaking** improvements. The public surface — `deploy-rs.lib.<system>.activate.*`, the `interface.json` config schema, the `deploy` CLI flags, and the `deploy`↔`activate` protocol — is unchanged.

## Commits
1. **chore: clippy lints + clippy/rustfmt/reuse checks** — resolves all clippy warnings, annotates the genuinely-many-arg functions with `#[allow]`, and adds three lint derivations to the flake `checks` (so they run in CI). The `reuse` check caught two pre-existing files missing SPDX headers (`src/command.rs`, `.github/workflows/check.yml`) — fixed.
2. **docs: example off deprecated `setActivate`** — `examples/simple` now uses `activate.custom` (the alias stays for back-compat).
3. **fix: avoid panics in the deploy waiter and flake-target parser** — the magic-rollback waiter `unwrap()`ped a oneshot `RecvError` (a successful activation finishing before the wait command returned would panic); now handled as success. The rnix fragment parser `unwrap()`ped AST nodes; malformed targets now return `ParseFlakeError` instead of panicking.
4. **feat: `activate.profile`** — a new additive activator that installs the closure into the target's nix3 `nix profile` (idempotent: replaces a previous generation of the same name). Existing activators untouched.
5. **feat: nullable optional fields in `interface.json`** — widens the schema so optional settings may be `null` (backward-compatible; also future-proofs a module-system consumer that emits explicit `null` defaults).

## Verification
Run in a `nixos/nix` (aarch64) container against a toy multi-node flake:
- `nix build .#checks.<sys>.{clippy,rustfmt,reuse,deploy-rs}` → all pass
- magic-rollback deploy → `Deployment confirmed.` (confirms the waiter fix doesn't regress the rollback path)
- `activate.profile` → installs + runs a package, idempotent on re-deploy
- `deploy` **with** schema checks and `fastConnection = null` → passes (exercises the nullable schema end-to-end)