### PR TITLE
fix: stream build logs when -L is passed

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -662,6 +662,12 @@ async fn run_deploy(
                 }
             });
 
+    // Progress bars only used when building on more than one remote host at once.
+    // For a purely local build, or a single remote host, there is no concurrency,
+    // so we let nix write its native output (native `-L`, errors and progress)
+    // directly to the terminal instead.
+    let use_progress = remote_build_map.len() > 1;
+
     // show progress information
     let remote_mp = mp.clone();
     let spinner_style = ProgressStyle::with_template("{spinner:.blue} {prefix} {sep:.blue} {msg}")
@@ -688,8 +694,13 @@ async fn run_deploy(
             #[allow(clippy::iter_kv_map)]
             for (_, profiles) in remote_build_map {
                 // spawn one future for each host
-                let pb = remote_mp.add(new_spinner());
-                pb.enable_steady_tick(Duration::from_millis(80));
+                let pb = if use_progress {
+                    let pb = remote_mp.add(new_spinner());
+                    pb.enable_steady_tick(Duration::from_millis(80));
+                    Some(pb)
+                } else {
+                    None
+                };
 
                 set.spawn(async move {
                     let mut res = Ok(());
@@ -698,12 +709,14 @@ async fn run_deploy(
                     for mut profile in profiles {
                         let nodename = profile.deploy_data.node_name.clone();
                         let profilename = profile.deploy_data.profile_name.clone();
-                        pb.set_prefix(format!(
-                            "Building profile '{}' on host '{}'",
-                            profilename, nodename
-                        ));
-                        pb.set_message("...");
-                        profile.deploy_data.progressbar = Some(pb.clone());
+                        if let Some(pb) = &pb {
+                            pb.set_prefix(format!(
+                                "Building profile '{}' on host '{}'",
+                                profilename, nodename
+                            ));
+                            pb.set_message("...");
+                            profile.deploy_data.progressbar = Some(pb.clone());
+                        }
 
                         info!(
                             "starting build of profile {} on node {}",
@@ -722,14 +735,16 @@ async fn run_deploy(
                         }
                     }
 
-                    match res {
-                        Ok(()) => {
-                            pb.set_style(finish_style());
-                            pb.finish_with_message("Done!");
-                        }
-                        Err(ref e) => {
-                            pb.set_style(finish_style_error());
-                            pb.finish_with_message(format!("Error: {}", e))
+                    if let Some(pb) = &pb {
+                        match res {
+                            Ok(()) => {
+                                pb.set_style(finish_style());
+                                pb.finish_with_message("Done!");
+                            }
+                            Err(ref e) => {
+                                pb.set_style(finish_style_error());
+                                pb.finish_with_message(format!("Error: {}", e));
+                            }
                         }
                     }
 
@@ -744,17 +759,28 @@ async fn run_deploy(
             let mut set = JoinSet::new();
 
             for mut data in local_builds.into_iter() {
-                let pb = mp.add(new_spinner());
-                pb.enable_steady_tick(Duration::from_millis(80));
-
                 let node_name = data.deploy_data.node_name.to_string();
                 let profile_name = data.deploy_data.profile_name.to_string();
-                pb.set_prefix(format!(
-                    "Building profile '{}' for host '{}'",
-                    profile_name, node_name
-                ));
-                pb.set_message("...");
-                data.deploy_data.progressbar = Some(pb.clone());
+
+                // Only render a spinner when we have to coordinate with the
+                // concurrent remote builds; otherwise let nix output natively.
+                let pb = if use_progress {
+                    let pb = mp.add(new_spinner());
+                    pb.enable_steady_tick(Duration::from_millis(80));
+                    pb.set_prefix(format!(
+                        "Building profile '{}' for host '{}'",
+                        profile_name, node_name
+                    ));
+                    pb.set_message("...");
+                    data.deploy_data.progressbar = Some(pb.clone());
+                    Some(pb)
+                } else {
+                    info!(
+                        "Building profile `{}` for node `{}`",
+                        profile_name, node_name
+                    );
+                    None
+                };
 
                 let res = deploy::push::build_profile(&data).await.map_err(|e| {
                     RunDeployError::BuildProfile(profile_name.clone(), node_name.clone(), e)
@@ -764,29 +790,35 @@ async fn run_deploy(
                     Ok(()) => {
                         set.spawn(async move {
                             let data = data.clone();
-                            pb.set_prefix(format!(
-                                "Pushing profile '{}' to host '{}'",
-                                profile_name, node_name
-                            ));
+                            if let Some(pb) = &pb {
+                                pb.set_prefix(format!(
+                                    "Pushing profile '{}' to host '{}'",
+                                    profile_name, node_name
+                                ));
+                            }
                             let res = deploy::push::push_profile(&data).await.map_err(|e| {
                                 RunDeployError::PushProfile(profile_name, node_name, e)
                             });
-                            match res {
-                                Ok(()) => {
-                                    pb.set_style(finish_style());
-                                    pb.finish_with_message("Done!");
-                                }
-                                Err(ref e) => {
-                                    pb.set_style(finish_style_error());
-                                    pb.finish_with_message(format!("Error: {}", e))
+                            if let Some(pb) = &pb {
+                                match res {
+                                    Ok(()) => {
+                                        pb.set_style(finish_style());
+                                        pb.finish_with_message("Done!");
+                                    }
+                                    Err(ref e) => {
+                                        pb.set_style(finish_style_error());
+                                        pb.finish_with_message(format!("Error: {}", e));
+                                    }
                                 }
                             }
                             res
                         });
                     }
                     Err(ref e) => {
-                        pb.set_style(finish_style_error());
-                        pb.finish_with_message(format!("Error: {}", e));
+                        if let Some(pb) = &pb {
+                            pb.set_style(finish_style_error());
+                            pb.finish_with_message(format!("Error: {}", e));
+                        }
                         // "spawn" a future that just returns the error when building locally fails
                         // this will ensure that the deployment is actually aborted in the error
                         // handling code below

--- a/src/push.rs
+++ b/src/push.rs
@@ -241,7 +241,8 @@ const RES_BUILD_LOG_LINE: i64 = 101;
 
 /// Accumulates the aggregate progress reported by `nix --log-format internal-json`
 /// so we can render a compact `x/y built, x/y copied` message next to the spinner,
-/// mirroring nix's own progress bar.
+/// mirroring nix's own progress bar. Only used when builds run concurrently (i.e.
+/// remote builds); local builds print nix's native output directly.
 #[derive(Default)]
 struct NixProgress {
     // Map of activity id -> activity type, so `result` events can be attributed.
@@ -344,7 +345,8 @@ impl NixProgress {
                             }
                         }
                     }
-                    // A line of build output from a running derivation.
+                    // A line of build output from a running derivation: shown as
+                    // the spinner's current-activity text.
                     Some(RES_BUILD_LOG_LINE) => {
                         if let Some(text) = fields
                             .and_then(|f| f.first())
@@ -451,26 +453,30 @@ pub async fn build_profile_remotely(
             .arg(derivation_name)
             .env("NIX_SSHOPTS", ssh_opts_str.clone());
 
-        if data.deploy_data.progressbar.is_some() {
-            copy_command.arg("--log-format").arg("internal-json");
-        }
-
-        debug!("copy command: {:?}", copy_command);
-
-        let mut child = copy_command
-            .stderr(Stdio::piped())
-            .stdout(Stdio::piped())
-            .spawn()
-            .expect("failed to spawn nix copy command");
-
         if let Some(pb) = &data.deploy_data.progressbar {
-            update_pb_with_child_output(pb, &mut child).await;
-        }
+            // Concurrent deploy: route nix's output through the spinner.
+            copy_command.arg("--log-format").arg("internal-json");
+            debug!("copy command: {:?}", copy_command);
+            let mut child = copy_command
+                .stderr(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .expect("failed to spawn nix copy command");
 
-        child
-            .wait()
-            .await
-            .map_err(|e| PushProfileError::Copy(command::CommandError::RunError(e)))?
+            update_pb_with_child_output(pb, &mut child).await;
+
+            child
+                .wait()
+                .await
+                .map_err(|e| PushProfileError::Copy(command::CommandError::RunError(e)))?
+        } else {
+            // No progress bar: let nix write its native output to the terminal.
+            debug!("copy command: {:?}", copy_command);
+            copy_command
+                .status()
+                .await
+                .map_err(|e| PushProfileError::Copy(command::CommandError::RunError(e)))?
+        }
     };
 
     match copy_command_status.code() {
@@ -490,26 +496,30 @@ pub async fn build_profile_remotely(
             .args(data.extra_build_args.clone())
             .env("NIX_SSHOPTS", ssh_opts_str.clone());
 
-        if data.deploy_data.progressbar.is_some() {
-            build_command.arg("--log-format").arg("internal-json");
-        }
-
-        debug!("build command: {:?}", build_command);
-
-        let mut child = build_command
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .expect("failed to spawn nix build command");
-
         if let Some(pb) = &data.deploy_data.progressbar {
-            update_pb_with_child_output(pb, &mut child).await;
-        }
+            // Concurrent deploy: route nix's output through the spinner.
+            build_command.arg("--log-format").arg("internal-json");
+            debug!("build command: {:?}", build_command);
+            let mut child = build_command
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .expect("failed to spawn nix build command");
 
-        child
-            .wait()
-            .await
-            .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?
+            update_pb_with_child_output(pb, &mut child).await;
+
+            child
+                .wait()
+                .await
+                .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?
+        } else {
+            // No progress bar: let nix write its native output to the terminal.
+            debug!("build command: {:?}", build_command);
+            build_command
+                .status()
+                .await
+                .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?
+        }
     };
 
     match build_exit_status.code() {
@@ -692,29 +702,32 @@ pub async fn push_profile(data: &PushProfileData) -> Result<(), PushProfileError
             .arg(&data.deploy_data.profile.profile_settings.path)
             .env("NIX_SSHOPTS", ssh_opts_str);
 
-        if data.deploy_data.progressbar.is_some() {
-            copy_command.arg("--log-format").arg("internal-json");
-        }
-
         debug!("copy command: {:?}", copy_command);
 
-        // Pipe the output so nix does not draw directly to the terminal (which
-        // corrupts the progress bars); instead route each line through the
-        // spinner's message via `update_pb_with_child_output`.
-        let mut child = copy_command
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .expect("failed to spawn nix copy command");
+        let copy_exit_status = if let Some(pb) = &data.deploy_data.progressbar {
+            // A progress bar is attached (concurrent deploy): pipe nix's output
+            // and route it through the spinner instead of letting it draw to the
+            // terminal (which would corrupt the bars).
+            copy_command.arg("--log-format").arg("internal-json");
+            let mut child = copy_command
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .expect("failed to spawn nix copy command");
 
-        if let Some(pb) = &data.deploy_data.progressbar {
             update_pb_with_child_output(pb, &mut child).await;
-        }
 
-        let copy_exit_status = child
-            .wait()
-            .await
-            .map_err(|e| PushProfileError::Copy(command::CommandError::RunError(e)))?;
+            child
+                .wait()
+                .await
+                .map_err(|e| PushProfileError::Copy(command::CommandError::RunError(e)))?
+        } else {
+            // No progress bar: let nix write its native output to the terminal.
+            copy_command
+                .status()
+                .await
+                .map_err(|e| PushProfileError::Copy(command::CommandError::RunError(e)))?
+        };
 
         match copy_exit_status.code() {
             Some(0) => (),

--- a/src/push.rs
+++ b/src/push.rs
@@ -232,12 +232,13 @@ pub async fn build_profile_locally(
 }
 
 // Nix `internal-json` activity types (see nix's `logging.hh`).
+const ACT_FILE_TRANSFER: i64 = 101;
 const ACT_COPY_PATHS: i64 = 103;
 const ACT_BUILDS: i64 = 104;
-const ACT_FILE_TRANSFER: i64 = 101;
-// Result types.
-const RES_PROGRESS: i64 = 105;
 const RES_BUILD_LOG_LINE: i64 = 101;
+const RES_PROGRESS: i64 = 105;
+// Nix verbosity levels: 0 = error, 1 = warning (higher = notice/info/debug).
+const LVL_WARN: i64 = 1;
 
 /// Accumulates the aggregate progress reported by `nix --log-format internal-json`
 /// so we can render a compact `x/y built, x/y copied` message next to the spinner,
@@ -254,6 +255,9 @@ struct NixProgress {
     // a running total of finished ones to render a single `X MiB DL` figure.
     download_active: HashMap<u64, u64>,
     download_done: u64,
+    // An error/warning message from the last ingested event, always surfaced so
+    // failures aren't reduced to a bare exit code.
+    pending_msg: Option<String>,
     // The most recent human-readable activity text (current path, build log line, ...).
     last_line: String,
 }
@@ -360,6 +364,21 @@ impl NixProgress {
                     _ => {}
                 }
             }
+            // Errors and warnings: always surfaced (independent of `-L`) so a
+            // failed build shows its reason instead of a bare exit code.
+            "msg" => {
+                let level = value
+                    .get("level")
+                    .and_then(serde_json::Value::as_i64)
+                    .unwrap_or(i64::MAX);
+                if level <= LVL_WARN {
+                    if let Some(msg) = value.get("msg").and_then(serde_json::Value::as_str) {
+                        if !msg.is_empty() {
+                            self.pending_msg = Some(msg.to_string());
+                        }
+                    }
+                }
+            }
             _ => {}
         }
         true
@@ -416,6 +435,10 @@ async fn update_pb_with_child_output(pb: &ProgressBar, child: &mut Child) {
         // Structured `@nix` events feed the aggregate counters; anything else
         // (e.g. a stray warning) is shown verbatim.
         if progress.ingest(&line) {
+            // Errors/warnings are always surfaced above the bar.
+            if let Some(msg) = progress.pending_msg.take() {
+                pb.println(msg);
+            }
             pb.set_message(progress.message());
         } else if !line.is_empty() {
             pb.set_message(line);


### PR DESCRIPTION
Problem: Recent async build feature broke -L/--print-build-logs.

Solution: When -L is set, stream each build-log line above the bar, prefixed with the derivation name like native `nix build -L`.