### PR TITLE
fix: stop swallowing nix output on non-concurrent builds

### DIFF
--- a/src/push.rs
+++ b/src/push.rs
@@ -208,13 +208,15 @@ pub async fn build_profile_locally(
             stderr: Vec::new(),
         }
     } else {
-        build_command
+        let child = build_command
             .stdout(Stdio::piped())
-            .stderr(Stdio::inherit());
-        command::Command::new(build_command)
-            .run()
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?;
+        child
+            .wait_with_output()
             .await
-            .map_err(PushProfileError::Build)?
+            .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?
     };
 
     match build_output.status.code() {
@@ -586,13 +588,15 @@ pub async fn build_profile_remotely(
         } else {
             // No progress bar: let nix write its native output to the terminal.
             debug!("build command: {:?}", build_command);
-            build_command
+            let child = build_command
                 .stdout(Stdio::piped())
-                .stderr(Stdio::inherit());
-            command::Command::new(build_command)
-                .run()
+                .stderr(Stdio::inherit())
+                .spawn()
+                .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?;
+            child
+                .wait_with_output()
                 .await
-                .map_err(PushProfileError::Build)?
+                .map_err(|e| PushProfileError::Build(command::CommandError::RunError(e)))?
         }
     };
 


### PR DESCRIPTION
Problem: `Command::run` goes through `tokio::process::Command::output`, which forces both stdout and stderr to piped regardless of the explicit `Stdio::inherit()` set right before it. So local and single remote host builds (no progress bar) silently captured nix's live build log, including --log-format internal-json output, and discarded it on success, breaking pipes into nix-output-monitor/nom.

Solution: Spawn the build command directly and read it back with `Child::wait_with_output`, which only reads the pipes that were actually configured. stdout stays piped for the realised output path, stderr stays inherited so nix's native output streams straight through.

fixes #386 