### PR TITLE
flake.nix: drop broken \. string escapes in sourceByRegex

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,13 +26,13 @@
           version = "0.1.0";
 
           src = final.lib.sourceByRegex ./. [
-            "Cargo\.lock"
-            "Cargo\.toml"
+            "Cargo.lock"
+            "Cargo.toml"
             "src"
             "src/bin"
-            ".*\.rs$"
+            ".*.rs$"
             "nix"
-            "nix/.*\.nix$"
+            "nix/.*.nix$"
           ];
 
           cargoLock.lockFile = ./Cargo.lock;


### PR DESCRIPTION
## What

Drops the backslash from the four `\.` occurrences in `flake.nix`'s `sourceByRegex` argument list.

## Why

As reported in #388, Lix warns that `\.` inside a Nix double-quoted string is an ill-defined escape. Nix's string-literal escaping already drops the backslash for unrecognized escapes like `\.`, so these strings were evaluating to a bare `.` at runtime all along — the regex engine never actually saw an escaped dot. Writing `.` directly produces the identical runtime string and silences the warning; no behavior change.

## How this was tested

I don't have `nix` available in my sandbox, so I could not run `nix build`/the flake checks locally. This is a 1:1 textual substitution (dropping 4 backslash characters) with no structural change, so I'm relying on CI to confirm the flake still evaluates and builds.

Closes #388

---

**AI disclosure:** This PR (diff, commit message, and this description) was authored by an AI coding agent (Claude). I found no CONTRIBUTING.md or AI-usage policy in this repo to check against.
