### PR TITLE
docs: fix README reference to removed deploy-rs.overlay attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ In the above configuration, `deploy-rs` is built from the flake, not from nixpkg
     deployPkgs = import nixpkgs {
       inherit system;
       overlays = [
-        deploy-rs.overlay # or deploy-rs.overlays.default
+        deploy-rs.overlays.default
         (self: super: { deploy-rs = { inherit (pkgs) deploy-rs; lib = super.deploy-rs.lib; }; })
       ];
     };


### PR DESCRIPTION
Closes #328

## What

`deploy-rs.overlay` was removed in 6fc0024; only `overlays.default` exists
now (confirmed against current `flake.nix`). The README's overlay example
still referenced the removed attribute, with a stale
`# or deploy-rs.overlays.default` comment sitting right next to it:

```nix
overlays = [
  deploy-rs.overlay # or deploy-rs.overlays.default
  ...
```

Fixed to just use the attribute that actually exists:

```nix
overlays = [
  deploy-rs.overlays.default
  ...
```

Left the unrelated stalled PR #329 alone as noted in the tracking issue —
this is an independent one-line fix against current `master`.

## Testing

Documentation-only, single-line change.

Marking this AI-assisted: this PR was authored by an AI coding agent
(Claude).
