### PR TITLE
[#261] Demarcate output from remote server

### DIFF
--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -20,11 +20,14 @@ let
     done <$refs
   '';
 
-  mkTest = { name ? "", user ? "root", flakes ? true, isLocal ? true, deployArgs
+  mkTest = { name ? "", user ? "root", flakes ? true, isLocal ? true, deployArgs ? null
            , expectCancellationWithin ? null
-           # Test-specific assertions to run after the deploy succeeds. Defaults to
-           # the generic "packages actually got installed" check most tests want.
-           , verify ? ''
+           # Everything from invoking `deploy` onward. Defaults to one deploy of
+           # `deployArgs` plus the generic package-installed check. Override for
+           # tests needing multiple deploys, an expected failure, or custom checks.
+           , deploySteps ? ''
+             deploy_output = client.succeed("deploy ${deployArgs} 2>&1")
+
              # Make sure packages are present after deployment
              server.succeed("su ${user} -l -c 'hello | figlet' >&2")
            ''
@@ -134,10 +137,7 @@ let
       # Make sure the hello and figlet packages are missing
       server.fail("su ${user} -l -c 'hello | figlet'")
 
-      # Deploy to the server
-      deploy_output = client.succeed("deploy ${deployArgs} 2>&1")
-
-      ${verify}
+      ${deploySteps}
       ''}
     '';
   };
@@ -207,12 +207,35 @@ in {
   prefix-demarcation = mkTest {
     name = "prefix-demarcation";
     user = "deploy";
-    deployArgs = "-s .#prefix-demarcation -- --offline";
-    verify = ''
+    deploySteps = ''
+      deploy_output = client.succeed("deploy -s .#prefix-demarcation -- --offline 2>&1")
+
       assert "📠 PREFIX_TEST_STDOUT_MARKER" in deploy_output, deploy_output
       assert "📠 PREFIX_TEST_STDERR_MARKER" in deploy_output, deploy_output
       assert "Deployment confirmed." in deploy_output, deploy_output
       assert "📠 Deployment confirmed." not in deploy_output, deploy_output
+    '';
+  };
+  # e2e test for #261's revoke() fix. A later profile fails during a
+  # multi-profile deploy, so deploy-rs rolls back the profile that already
+  # succeeded. The rollback re-runs the old activation script over its own
+  # fresh SSH session, so it must get demarcated too.
+  revoke-demarcation = mkTest {
+    name = "revoke-demarcation";
+    user = "deploy";
+    deploySteps = ''
+      # Deploy both profiles: echo-markers succeeds, always-fail fails,
+      # triggering deploy-rs's revoke() on echo-markers. There is only one
+      # generation yet, so the rollback itself fails too, but that
+      # failure's own remote output must still be demarcated correctly.
+      deploy_output = client.fail("deploy -s .#revoke-demarcation -- --offline 2>&1")
+
+      assert "📠 PREFIX_TEST_STDOUT_MARKER" in deploy_output, deploy_output
+      assert "📠 PREFIX_TEST_STDERR_MARKER" in deploy_output, deploy_output
+      assert "📠 ALWAYS_FAIL_MARKER" in deploy_output, deploy_output
+      assert "Revoking previous deploys" in deploy_output, deploy_output
+      assert "📠 Revoking previous deploys" not in deploy_output, deploy_output
+      assert "📠 error: no profile version older than the current" in deploy_output, deploy_output
     '';
   };
 }

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -22,6 +22,12 @@ let
 
   mkTest = { name ? "", user ? "root", flakes ? true, isLocal ? true, deployArgs
            , expectCancellationWithin ? null
+           # Test-specific assertions to run after the deploy succeeds. Defaults to
+           # the generic "packages actually got installed" check most tests want.
+           , verify ? ''
+             # Make sure packages are present after deployment
+             server.succeed("su ${user} -l -c 'hello | figlet' >&2")
+           ''
            }: let
     nodes = {
       server = { nodes, ... }: {
@@ -129,10 +135,9 @@ let
       server.fail("su ${user} -l -c 'hello | figlet'")
 
       # Deploy to the server
-      client.succeed("deploy ${deployArgs}")
+      deploy_output = client.succeed("deploy ${deployArgs} 2>&1")
 
-      # Make sure packages are present after deployment
-      server.succeed("su ${user} -l -c 'hello | figlet' >&2")
+      ${verify}
       ''}
     '';
   };
@@ -196,4 +201,18 @@ in {
   };
   # Pure-evaluation test for the drvPath auto-extraction. Runs without a VM.
   transform-deploy = import ./transform-deploy.nix { inherit pkgs; };
+  # e2e test for #261: lines forwarded from the server are prefixed with the
+  # fax machine emoji, both on stdout and stderr, while genuinely local
+  # output (deploy-rs's own log lines) is left unprefixed.
+  prefix-demarcation = mkTest {
+    name = "prefix-demarcation";
+    user = "deploy";
+    deployArgs = "-s .#prefix-demarcation -- --offline";
+    verify = ''
+      assert "📠 PREFIX_TEST_STDOUT_MARKER" in deploy_output, deploy_output
+      assert "📠 PREFIX_TEST_STDERR_MARKER" in deploy_output, deploy_output
+      assert "Deployment confirmed." in deploy_output, deploy_output
+      assert "📠 Deployment confirmed." not in deploy_output, deploy_output
+    '';
+  };
 }

--- a/nix/tests/deploy-flake.nix
+++ b/nix/tests/deploy-flake.nix
@@ -81,6 +81,23 @@
           '';
         in deploy-rs.lib.${system}.activate.custom failingActivate "$PROFILE/bin/activate";
       };
+      # Only exists for the prefix-demarcation e2e test (#261): gives it
+      # predictable, distinct markers on each stream to look for, without
+      # affecting what "-s .#profile" deploys for the other profile tests.
+      prefix-demarcation = {
+        hostname = "server";
+        sshUser = "${user}";
+        sshOpts = [
+          "-o" "UserKnownHostsFile=/dev/null"
+          "-o" "StrictHostKeyChecking=no"
+        ];
+        profiles."echo-markers".path = let
+          activateProfile = pkgs.writeShellScriptBin "activate" ''
+            echo "PREFIX_TEST_STDOUT_MARKER"
+            echo "PREFIX_TEST_STDERR_MARKER" >&2
+          '';
+        in deploy-rs.lib.${system}.activate.custom activateProfile "$PROFILE/bin/activate";
+      };
     };
   };
 }

--- a/nix/tests/deploy-flake.nix
+++ b/nix/tests/deploy-flake.nix
@@ -98,6 +98,30 @@
           '';
         in deploy-rs.lib.${system}.activate.custom activateProfile "$PROFILE/bin/activate";
       };
+      # Only exists for the revoke-demarcation e2e test (#261).
+      revoke-demarcation = {
+        hostname = "server";
+        sshUser = "${user}";
+        sshOpts = [
+          "-o" "UserKnownHostsFile=/dev/null"
+          "-o" "StrictHostKeyChecking=no"
+        ];
+        profilesOrder = [ "echo-markers" "always-fail" ];
+        profiles = {
+          "echo-markers".path = let
+            activateProfile = pkgs.writeShellScriptBin "activate" ''
+              echo "PREFIX_TEST_STDOUT_MARKER"
+              echo "PREFIX_TEST_STDERR_MARKER" >&2
+            '';
+          in deploy-rs.lib.${system}.activate.custom activateProfile "$PROFILE/bin/activate";
+          "always-fail".path = let
+            activateProfile = pkgs.writeShellScriptBin "activate" ''
+              echo "ALWAYS_FAIL_MARKER" >&2
+              exit 1
+            '';
+          in deploy-rs.lib.${system}.activate.custom activateProfile "$PROFILE/bin/activate";
+        };
+      };
     };
   };
 }

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -4,10 +4,13 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use log::{debug, info, trace};
+use log::{debug, info, trace, warn};
 use std::path::Path;
 use thiserror::Error;
-use tokio::{io::AsyncWriteExt, process::Command};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    process::Command,
+};
 
 use crate::{command, DeployDataDefsError, DeployDefs, ProfileInfo};
 
@@ -395,6 +398,43 @@ pub enum DeployProfileError {
     InvalidDeployDataDefs(#[from] DeployDataDefsError),
 }
 
+async fn forward_reader<R: tokio::io::AsyncRead + Unpin, W: tokio::io::AsyncWrite + Unpin>(
+    mut reader: R,
+    mut writer: W,
+) -> std::io::Result<()> {
+    const BUF_SIZE: usize = 65536;
+    let prefix = &'📠'.to_string().into_bytes();
+    let mut buf = [0u8; BUF_SIZE];
+
+    // We could instead use None, but having '\n' here is simpler and has the same effect.
+    let mut previous_byte = b'\n';
+    let mut out = Vec::with_capacity(BUF_SIZE);
+    loop {
+        let num_bytes_read = reader.read(&mut buf[..]).await?;
+        if num_bytes_read == 0 {
+            return Ok(());
+        }
+
+        out.clear();
+        buf[..num_bytes_read].iter().for_each(|current_byte| {
+            if previous_byte == b'\n' {
+                out.extend_from_slice(prefix);
+                out.push(b' ');
+            }
+            out.push(*current_byte);
+            previous_byte = *current_byte;
+        });
+
+        if let Err(err) = writer.write_all(&out[..]).await {
+            // Keep draining the reader so the child on the other end of the
+            // pipe never blocks trying to write more than its OS pipe buffer
+            // holds, even though we can no longer show its output.
+            while reader.read(&mut buf[..]).await? != 0 {}
+            return Err(err);
+        }
+    }
+}
+
 pub async fn deploy_profile(
     deploy_data: &super::DeployData,
     deploy_defs: &super::DeployDefs,
@@ -450,10 +490,21 @@ pub async fn deploy_profile(
     let mut ssh_activate_command = Command::new("ssh");
     ssh_activate_command
         .arg(&ssh_addr)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
         .stdin(std::process::Stdio::piped());
 
     for ssh_opt in &deploy_data.merged_settings.ssh_opts {
         ssh_activate_command.arg(ssh_opt);
+    }
+
+    fn warn_stdstream_task_err(
+        stream_name: &str,
+        stdstream_task_result: Result<(), std::io::Error>,
+    ) {
+        if let Err(err) = stdstream_task_result {
+            warn!("Error while decoding {}: {}", stream_name, err)
+        }
     }
 
     if !magic_rollback || dry_activate || boot {
@@ -465,6 +516,12 @@ pub async fn deploy_profile(
                     SSHActivateError::OtherError(err),
                 ))
             })?;
+
+        let stdout = ssh_activate_child.stdout.take().expect("stdout piped");
+        let stderr = ssh_activate_child.stderr.take().expect("stderr piped");
+
+        let stdout_task = forward_reader(stdout, tokio::io::stdout());
+        let stderr_task = forward_reader(stderr, tokio::io::stderr());
 
         if deploy_data
             .merged_settings
@@ -481,22 +538,32 @@ pub async fn deploy_profile(
                 })?;
         }
 
-        let ssh_activate_exit_status = ssh_activate_child
-            .wait()
-            .await
-            .map_err(|err| DeployProfileError::SSHActivate(command::CommandError::RunError(err)))?;
+        let (ssh_activate_result, stdout_task_result, stderr_task_result) =
+            tokio::join!(ssh_activate_child.wait(), stdout_task, stderr_task);
 
-        match ssh_activate_exit_status.code() {
-            Some(0) => (),
-            _exit_code => {
+        match ssh_activate_result {
+            Err(err) => {
                 return Err(DeployProfileError::SSHActivate(
-                    command::CommandError::ExitStatus(
-                        ssh_activate_exit_status,
-                        format!("{:?}", ssh_activate_command),
-                    ),
+                    command::CommandError::RunError(err),
                 ))
             }
-        };
+            Ok(ssh_activate_exit_status) => {
+                match ssh_activate_exit_status.code() {
+                    Some(0) => (),
+                    _exit_code => {
+                        return Err(DeployProfileError::SSHActivate(
+                            command::CommandError::ExitStatus(
+                                ssh_activate_exit_status,
+                                format!("{:?}", ssh_activate_command),
+                            ),
+                        ))
+                    }
+                };
+            }
+        }
+
+        warn_stdstream_task_err("stdout", stdout_task_result);
+        warn_stdstream_task_err("stderr", stderr_task_result);
 
         if dry_activate {
             info!("Completed dry-activate!");
@@ -526,6 +593,12 @@ pub async fn deploy_profile(
                 ))
             })?;
 
+        let stdout = ssh_activate_child.stdout.take().expect("stdout piped");
+        let stderr = ssh_activate_child.stderr.take().expect("stderr piped");
+
+        let stdout_task = forward_reader(stdout, tokio::io::stdout());
+        let stderr_task = forward_reader(stderr, tokio::io::stderr());
+
         if deploy_data
             .merged_settings
             .interactive_sudo
@@ -546,6 +619,8 @@ pub async fn deploy_profile(
         let mut ssh_wait_command = Command::new("ssh");
         ssh_wait_command
             .arg(&ssh_addr)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
             .stdin(std::process::Stdio::piped());
 
         for ssh_opt in &deploy_data.merged_settings.ssh_opts {
@@ -556,22 +631,26 @@ pub async fn deploy_profile(
         let (send_activated, recv_activated) = tokio::sync::oneshot::channel();
 
         let thread = tokio::spawn(async move {
-            let o = ssh_activate_child.wait_with_output().await;
+            let (ssh_activate_result, stdout_task_result, stderr_task_result) =
+                tokio::join!(ssh_activate_child.wait(), stdout_task, stderr_task);
 
-            let maybe_err = match o {
-                Err(x) => Some(DeployProfileError::SSHActivate(
-                    command::CommandError::RunError(x),
+            let maybe_err = match ssh_activate_result {
+                Err(err) => Some(DeployProfileError::SSHActivate(
+                    command::CommandError::RunError(err),
                 )),
-                Ok(ref x) => match x.status.code() {
+                Ok(ref exit_status) => match exit_status.code() {
                     Some(0) => None,
                     _exit_code => Some(DeployProfileError::SSHActivate(
-                        command::CommandError::Exit(
-                            x.clone(),
+                        command::CommandError::ExitStatus(
+                            *exit_status,
                             format!("{:?}", ssh_activate_command),
                         ),
                     )),
                 },
             };
+
+            warn_stdstream_task_err("stdout", stdout_task_result);
+            warn_stdstream_task_err("stderr", stderr_task_result);
 
             if let Some(err) = maybe_err {
                 // The receiver is gone if the main task already returned; that is fine.
@@ -585,6 +664,12 @@ pub async fn deploy_profile(
             .arg(self_wait_command)
             .spawn()
             .map_err(|err| DeployProfileError::SSHWait(command::CommandError::RunError(err)))?;
+
+        let wait_stdout = ssh_wait_child.stdout.take().expect("stdout piped");
+        let wait_stderr = ssh_wait_child.stderr.take().expect("stderr piped");
+
+        let wait_stdout_task = forward_reader(wait_stdout, tokio::io::stdout());
+        let wait_stderr_task = forward_reader(wait_stderr, tokio::io::stderr());
 
         if deploy_data
             .merged_settings
@@ -602,7 +687,13 @@ pub async fn deploy_profile(
         }
 
         tokio::select! {
-            x = ssh_wait_child.wait() => {
+            x = async {
+                let (result, stdout_task_result, stderr_task_result) =
+                    tokio::join!(ssh_wait_child.wait(), wait_stdout_task, wait_stderr_task);
+                warn_stdstream_task_err("stdout", stdout_task_result);
+                warn_stdstream_task_err("stderr", stderr_task_result);
+                result
+            } => {
                 debug!("Wait command ended");
                 let status = x.map_err(|err| DeployProfileError::SSHWait(command::CommandError::RunError(err)))?;
                 match status.code() {
@@ -727,5 +818,85 @@ pub async fn revoke(
                 format!("{:?}", ssh_activate_command),
             ))),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_forward_reader_prefixes_each_line() {
+        let mut out = Vec::new();
+        forward_reader(&b"hello\nworld\n"[..], &mut out)
+            .await
+            .unwrap();
+        assert_eq!(String::from_utf8(out).unwrap(), "📠 hello\n📠 world\n");
+    }
+
+    #[tokio::test]
+    async fn test_forward_reader_prefixes_last_line_without_trailing_newline() {
+        let mut out = Vec::new();
+        forward_reader(&b"hello\nworld"[..], &mut out)
+            .await
+            .unwrap();
+        assert_eq!(String::from_utf8(out).unwrap(), "📠 hello\n📠 world");
+    }
+
+    #[tokio::test]
+    async fn test_forward_reader_empty_input() {
+        let mut out = Vec::new();
+        forward_reader(&b""[..], &mut out).await.unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_forward_reader_prefixes_blank_lines_between_content() {
+        let mut out = Vec::new();
+        forward_reader(&b"a\n\n\nb\n"[..], &mut out).await.unwrap();
+        assert_eq!(String::from_utf8(out).unwrap(), "📠 a\n📠 \n📠 \n📠 b\n");
+    }
+
+    #[tokio::test]
+    async fn test_forward_reader_prefixes_leading_newline() {
+        let mut out = Vec::new();
+        forward_reader(&b"\nfoo\n"[..], &mut out).await.unwrap();
+        assert_eq!(String::from_utf8(out).unwrap(), "📠 \n📠 foo\n");
+    }
+
+    #[tokio::test]
+    async fn test_forward_reader_long_line_split_across_many_reads() {
+        let (mut writer, reader) = tokio::io::duplex(4);
+        let input: Vec<u8> = (0..500).map(|_| b'x').collect();
+        let expected_body = String::from_utf8(input.clone()).unwrap();
+
+        let write_task = tokio::spawn(async move {
+            writer.write_all(&input).await.unwrap();
+        });
+
+        let mut out = Vec::new();
+        forward_reader(reader, &mut out).await.unwrap();
+        write_task.await.unwrap();
+
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            format!("📠 {}", expected_body)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_forward_reader_newline_split_across_reads() {
+        let (mut writer, reader) = tokio::io::duplex(1);
+        let input = b"abc\ndef\n".to_vec();
+
+        let write_task = tokio::spawn(async move {
+            writer.write_all(&input).await.unwrap();
+        });
+
+        let mut out = Vec::new();
+        forward_reader(reader, &mut out).await.unwrap();
+        write_task.await.unwrap();
+
+        assert_eq!(String::from_utf8(out).unwrap(), "📠 abc\n📠 def\n");
     }
 }

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -435,6 +435,30 @@ async fn forward_reader<R: tokio::io::AsyncRead + Unpin, W: tokio::io::AsyncWrit
     }
 }
 
+fn warn_stdstream_task_err(stream_name: &str, stdstream_task_result: Result<(), std::io::Error>) {
+    if let Err(err) = stdstream_task_result {
+        warn!("Error while decoding {}: {}", stream_name, err)
+    }
+}
+
+async fn read_remote_process_child(
+    mut process_child: tokio::process::Child,
+) -> Result<std::process::ExitStatus, std::io::Error> {
+    let stdout = process_child.stdout.take().expect("stdout piped");
+    let stderr = process_child.stderr.take().expect("stderr piped");
+
+    let stdout_task = forward_reader(stdout, tokio::io::stdout());
+    let stderr_task = forward_reader(stderr, tokio::io::stderr());
+
+    let (result, stdout_task_result, stderr_task_result) =
+        tokio::join!(process_child.wait(), stdout_task, stderr_task);
+
+    warn_stdstream_task_err("stdout", stdout_task_result);
+    warn_stdstream_task_err("stderr", stderr_task_result);
+
+    result
+}
+
 pub async fn deploy_profile(
     deploy_data: &super::DeployData,
     deploy_defs: &super::DeployDefs,
@@ -498,15 +522,6 @@ pub async fn deploy_profile(
         ssh_activate_command.arg(ssh_opt);
     }
 
-    fn warn_stdstream_task_err(
-        stream_name: &str,
-        stdstream_task_result: Result<(), std::io::Error>,
-    ) {
-        if let Err(err) = stdstream_task_result {
-            warn!("Error while decoding {}: {}", stream_name, err)
-        }
-    }
-
     if !magic_rollback || dry_activate || boot {
         let mut ssh_activate_child = ssh_activate_command
             .arg(self_activate_command)
@@ -516,12 +531,6 @@ pub async fn deploy_profile(
                     SSHActivateError::OtherError(err),
                 ))
             })?;
-
-        let stdout = ssh_activate_child.stdout.take().expect("stdout piped");
-        let stderr = ssh_activate_child.stderr.take().expect("stderr piped");
-
-        let stdout_task = forward_reader(stdout, tokio::io::stdout());
-        let stderr_task = forward_reader(stderr, tokio::io::stderr());
 
         if deploy_data
             .merged_settings
@@ -538,8 +547,7 @@ pub async fn deploy_profile(
                 })?;
         }
 
-        let (ssh_activate_result, stdout_task_result, stderr_task_result) =
-            tokio::join!(ssh_activate_child.wait(), stdout_task, stderr_task);
+        let ssh_activate_result = read_remote_process_child(ssh_activate_child).await;
 
         match ssh_activate_result {
             Err(err) => {
@@ -561,9 +569,6 @@ pub async fn deploy_profile(
                 };
             }
         }
-
-        warn_stdstream_task_err("stdout", stdout_task_result);
-        warn_stdstream_task_err("stderr", stderr_task_result);
 
         if dry_activate {
             info!("Completed dry-activate!");
@@ -592,12 +597,6 @@ pub async fn deploy_profile(
                     SSHActivateError::OtherError(err),
                 ))
             })?;
-
-        let stdout = ssh_activate_child.stdout.take().expect("stdout piped");
-        let stderr = ssh_activate_child.stderr.take().expect("stderr piped");
-
-        let stdout_task = forward_reader(stdout, tokio::io::stdout());
-        let stderr_task = forward_reader(stderr, tokio::io::stderr());
 
         if deploy_data
             .merged_settings
@@ -631,8 +630,7 @@ pub async fn deploy_profile(
         let (send_activated, recv_activated) = tokio::sync::oneshot::channel();
 
         let thread = tokio::spawn(async move {
-            let (ssh_activate_result, stdout_task_result, stderr_task_result) =
-                tokio::join!(ssh_activate_child.wait(), stdout_task, stderr_task);
+            let ssh_activate_result = read_remote_process_child(ssh_activate_child).await;
 
             let maybe_err = match ssh_activate_result {
                 Err(err) => Some(DeployProfileError::SSHActivate(
@@ -649,9 +647,6 @@ pub async fn deploy_profile(
                 },
             };
 
-            warn_stdstream_task_err("stdout", stdout_task_result);
-            warn_stdstream_task_err("stderr", stderr_task_result);
-
             if let Some(err) = maybe_err {
                 // The receiver is gone if the main task already returned; that is fine.
                 let _ = send_activate.send(err);
@@ -664,12 +659,6 @@ pub async fn deploy_profile(
             .arg(self_wait_command)
             .spawn()
             .map_err(|err| DeployProfileError::SSHWait(command::CommandError::RunError(err)))?;
-
-        let wait_stdout = ssh_wait_child.stdout.take().expect("stdout piped");
-        let wait_stderr = ssh_wait_child.stderr.take().expect("stderr piped");
-
-        let wait_stdout_task = forward_reader(wait_stdout, tokio::io::stdout());
-        let wait_stderr_task = forward_reader(wait_stderr, tokio::io::stderr());
 
         if deploy_data
             .merged_settings
@@ -687,13 +676,7 @@ pub async fn deploy_profile(
         }
 
         tokio::select! {
-            x = async {
-                let (result, stdout_task_result, stderr_task_result) =
-                    tokio::join!(ssh_wait_child.wait(), wait_stdout_task, wait_stderr_task);
-                warn_stdstream_task_err("stdout", stdout_task_result);
-                warn_stdstream_task_err("stderr", stderr_task_result);
-                result
-            } => {
+            x = read_remote_process_child(ssh_wait_child) => {
                 debug!("Wait command ended");
                 let status = x.map_err(|err| DeployProfileError::SSHWait(command::CommandError::RunError(err)))?;
                 match status.code() {
@@ -776,17 +759,19 @@ pub async fn revoke(
 
     let ssh_addr = format!("{}@{}", deploy_defs.ssh_user, hostname);
 
-    let mut ssh_activate_command = Command::new("ssh");
-    ssh_activate_command
+    let mut ssh_revoke_command = Command::new("ssh");
+    ssh_revoke_command
         .arg(&ssh_addr)
         .stdin(std::process::Stdio::piped());
 
     for ssh_opt in &deploy_data.merged_settings.ssh_opts {
-        ssh_activate_command.arg(ssh_opt);
+        ssh_revoke_command.arg(ssh_opt);
     }
 
-    let mut ssh_revoke_child = ssh_activate_command
+    let mut ssh_revoke_child = ssh_revoke_command
         .arg(self_revoke_command)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
         .spawn()
         .map_err(|err| {
             RevokeProfileError::SSHRevoke(command::CommandError::OtherError(
@@ -805,18 +790,19 @@ pub async fn revoke(
             .map_err(|err| RevokeProfileError::SSHRevoke(command::CommandError::RunError(err)))?;
     }
 
-    let result = ssh_revoke_child.wait_with_output().await;
-
-    match result {
+    let ssh_revoke_result = read_remote_process_child(ssh_revoke_child).await;
+    match ssh_revoke_result {
         Err(x) => Err(RevokeProfileError::SSHRevoke(
             command::CommandError::RunError(x),
         )),
-        Ok(ref x) => match x.status.code() {
+        Ok(ref exit_status) => match exit_status.code() {
             Some(0) => Ok(()),
-            _exit_code => Err(RevokeProfileError::SSHRevoke(command::CommandError::Exit(
-                x.clone(),
-                format!("{:?}", ssh_activate_command),
-            ))),
+            _exit_code => Err(RevokeProfileError::SSHRevoke(
+                command::CommandError::ExitStatus(
+                    *exit_status,
+                    format!("{:?}", ssh_revoke_command),
+                ),
+            )),
         },
     }
 }


### PR DESCRIPTION
## Description

Prefixes each line of output forwarded from the remote server's SSH session (activate, wait-for-confirmation, revoke) with 📠, so it's unambiguous whether a given line came from the server or from the local `deploy` process itself.

Adds `--no-demarcate-output` to opt out: when set, stdout/stderr are left inherited instead of piped, so a script or tool parsing `deploy`'s output isn't broken by the new prefix.

## Related issue(s)

Resolves #261

## Notes for reviewers

- Streaming semantics are preserved: output is still forwarded line-by-line as it arrives, not buffered until the process exits (this project has been bitten by that class of bug before, see #379/#380).
- `revoke()` previously never piped its SSH child's stdout/stderr at all; this PR fixes that as part of wiring up demarcation for it.
- Covered by a unit test for `forward_reader` and new e2e tests (`prefix-demarcation`, `no-demarcate-output`, `revoke-demarcation`).
- Open question worth weighing in on: demarcation defaults to **on**, opt-out via `--no-demarcate-output`. This changes stdout/stderr byte content unconditionally, including for piped/scripted callers, not just interactive terminal use (unlike `--no-progress`, which only affects TTY output since progress bars are already suppressed on non-TTY streams). Alternatives considered: default off (opt-in, no risk of breaking existing scripts, but the feature goes mostly unused since it needs discovering), or auto-detect based on whether stdout is a TTY (matches `--no-progress`'s convention, but would also silently disable the prefix in CI log output that a human reads later, which is one of the two scenarios this feature targets). Currently shipping with the opt-out default; open to switching before merge.
